### PR TITLE
Reactivation of support for abort actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ ./runtests
 
 ## Input Format
 
-The tool operates on CSV files with a fixed column order. There are three main input formats: *job sets*, *precedence constraints*, and *abort actions* (abort actions are not supported currently in the version 3.0.0). 
+The tool operates on CSV files with a fixed column order. There are three main input formats: *job sets*, *precedence constraints*, and *abort actions*. 
 
 ### Job Sets
 
@@ -198,7 +198,7 @@ The tool does not check whether the provided structure actually forms a DAG. If 
 
 ### Aborting Jobs Past a Certain Point
 
-Older versions of the uniprocessor analysis (prior to v3.0.0) also supports so-called **abort actions**, which allow specifying that if a job executes past a certain point in time, it will be forcefully stopped and discarded by the runtime environment. To enable this support, pass a CSV file containing a list of abort actions using the `-a` option. For example:
+The analysis also supports so-called **abort actions**, which allow specifying that if a job executes past a certain point in time, it will be forcefully stopped and discarded by the runtime environment. To enable this support, pass a CSV file containing a list of abort actions using the `-a` option. For example:
 
 ```
 $ build/nptest -g examples/abort.jobs.csv -c -a examples/abort.actions.csv

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -1272,7 +1272,7 @@ namespace NP {
 							new_or_merge_state(*next, *s, j.get_job_index(), predecessors_of(j),
 								Interval<Time>{_st}, ftimes, next->get_scheduled_jobs(), successors, predecessors_suspensions, earliest_certain_gang_source_job_disptach(n, *s, j), p);
 
-							// make sure we didn't skip any jobsm which would then certainly miss its deadline
+							// make sure we didn't skip any jobs which would then certainly miss its deadline
 							// only do that if we stop the analysis when a deadline miss is found 
 							if (be_naive && early_exit) {
 								check_for_deadline_misses(n, *next);

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -1172,7 +1172,6 @@ namespace NP {
 							if (_st.first >= lt) {
 								// job doesn't even start, it is skipped immediately
 								ftimes = Interval<Time>{ _st };
-								observed_deadline_miss = true;
 							}
 							else {
 								// The job can start its execution but we check

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -41,6 +41,7 @@ namespace NP {
 			typedef Scheduling_problem<Time> Problem;
 			typedef typename Scheduling_problem<Time>::Workload Workload;
 			typedef typename Scheduling_problem<Time>::Precedence_constraints Precedence_constraints;
+			typedef typename Scheduling_problem<Time>::Abort_actions Abort_actions;
 			typedef Schedule_state<Time> State;
 			typedef typename std::vector<Interval<Time>> CoreAvailability;
 
@@ -50,17 +51,13 @@ namespace NP {
 				const Problem& prob,
 				const Analysis_options& opts)
 			{
-				// doesn't yet support exploration after deadline miss
-				assert(opts.early_exit);
-
-				State_space* s = new State_space(prob.jobs, prob.prec, prob.num_processors, opts.timeout,
-					opts.max_depth, opts.use_supernodes);
+				State_space* s = new State_space(prob.jobs, prob.prec, prob.aborts, prob.num_processors, 
+					opts.timeout, opts.max_depth, opts.early_exit, opts.use_supernodes);
 				s->be_naive = opts.be_naive;
 				s->cpu_time.start();
 				s->explore();
 				s->cpu_time.stop();
 				return s;
-
 			}
 
 			// convenience interface for tests
@@ -102,7 +99,7 @@ namespace NP {
 
 			bool is_schedulable() const
 			{
-				return !aborted;
+				return !aborted && !observed_deadline_miss;
 			}
 
 			bool was_timed_out() const
@@ -256,6 +253,8 @@ namespace NP {
 
 			bool aborted;
 			bool timed_out;
+			bool observed_deadline_miss;
+			bool early_exit;
 
 			const unsigned int max_depth;
 
@@ -281,14 +280,17 @@ namespace NP {
 
 			typedef std::vector<std::pair<Job_ref, Interval<Time>>> Suspensions_list;
 
+			// not touched after initialization
 			std::vector<Suspensions_list> _predecessors_suspensions;
 			std::vector<Suspensions_list> _successors;
-
+			// use these const references to ensure read-only access
 			const std::vector<Suspensions_list>& predecessors_suspensions;
 			const std::vector<Suspensions_list>& successors;
 
-			Nodes_storage nodes_storage;
+			// list of actions when a job is aborted
+			std::vector<const Abort_action<Time>*> abort_actions;
 
+			Nodes_storage nodes_storage;
 			Nodes_map nodes_by_key;
 
 #ifdef CONFIG_PARALLEL
@@ -311,13 +313,16 @@ namespace NP {
 
 			State_space(const Workload& jobs,
 				const Precedence_constraints& edges,
+				const Abort_actions& aborts,
 				unsigned int num_cpus,
 				double max_cpu_time = 0,
 				unsigned int max_depth = 0,
+				bool early_exit = true,
 				bool use_supernodes = true)
 				: jobs(jobs)
 				, aborted(false)
 				, timed_out(false)
+				, observed_deadline_miss(false)
 				, be_naive(false)
 				, timeout(max_cpu_time)
 				, max_depth(max_depth)
@@ -339,6 +344,8 @@ namespace NP {
 				, _successors(jobs.size())
 				, predecessors_suspensions(_predecessors_suspensions)
 				, successors(_successors)
+				, early_exit(early_exit)
+				, abort_actions(jobs.size(), NULL)
 				, use_supernodes(use_supernodes)
 #ifdef CONFIG_PARALLEL
 				, partial_rta(jobs.size())
@@ -364,6 +371,10 @@ namespace NP {
 					_jobs_by_deadline.insert({ j.get_deadline(), &j });
 				}
 
+				for (const Abort_action<Time>& a : aborts) {
+					const Job<Time>& j = lookup<Time>(jobs, a.get_id());
+					abort_actions[j.get_job_index()] = &a;
+				}
 			}
 
 		private:
@@ -402,8 +413,12 @@ namespace NP {
 				Response_times& r, const Job<Time>& j, Interval<Time> range)
 			{
 				update_finish_times(r, j.get_job_index(), range);
-				if (j.exceeds_deadline(range.upto()))
-					aborted = true;
+				if (j.exceeds_deadline(range.upto())) {
+					observed_deadline_miss = true;
+
+					if (early_exit)
+						aborted = true;
+				}
 			}
 
 			void update_finish_times(const Job<Time>& j, Interval<Time> range)
@@ -867,6 +882,16 @@ namespace NP {
 				return std::min(t_wos, t_ws);
 			}
 
+			Time earliest_job_abortion(const Abort_action<Time>& a)
+			{
+				return a.earliest_trigger_time() + a.least_cleanup_cost();
+			}
+
+			Time latest_job_abortion(const Abort_action<Time>& a)
+			{
+				return a.latest_trigger_time() + a.maximum_cleanup_cost();
+			}
+
 			// assumes j is ready
 			// NOTE: we don't use Interval<Time> here because the
 			//       Interval c'tor sorts its arguments.
@@ -1128,20 +1153,42 @@ namespace NP {
 						if (_st.first > t_wc || _st.first >= t_high || _st.first >= t_avail)
 							continue; // nope, not next job that can be dispatched in state s, try the next state.
 
-						Interval<Time> st{ _st };
+						//calculate the job finish time interval
+						Interval<Time> ftimes;
+						auto exec_time = j.get_cost(p);
+						Time eft = _st.first + exec_time.min();
+						Time lft = _st.second + exec_time.max();
+
+						// check for possible abort actions
+						auto j_idx = j.get_job_index();
+						if (abort_actions[j_idx]) {
+							auto et = abort_actions[j_idx]->earliest_trigger_time();
+							// Rule: if we're certainly past the trigger, the job is
+							//       completely skipped.
+							if (_st.first >= et)
+								// job doesn't even start, is skipped immediately
+								continue;
+
+							// The job can start its execution but we check
+							// if the job must be aborted before it finishes
+							auto eat = earliest_job_abortion(*abort_actions[j_idx]);
+							auto lat = latest_job_abortion(*abort_actions[j_idx]);
+							ftimes = Interval<Time>{ std::min(eft, eat), std::min(lft, lat) };
+						}
+						else {
+							// compute range of possible finish times
+							ftimes = Interval<Time>{ eft, lft };
+						}
 
 						// yep, job j is a feasible successor in state s
-						dispatched_one = true;
-
-						// compute range of possible finish times
-						Interval<Time> ftimes = st + j.get_cost(p);
+						dispatched_one = true;						
 
 						// update finish-time estimates
 						update_finish_times(j, ftimes);
 
 						if (use_supernodes == false)
 						{
-							next = &(dispatch_wo_supernodes(n, *s, j, st, ftimes, p));
+							next = &(dispatch_wo_supernodes(n, *s, j, Interval<Time>{_st}, ftimes, p));
 						}
 						else
 						{
@@ -1217,7 +1264,7 @@ namespace NP {
 							// next should always exist at this point, possibly without states in it
 							// create a new state resulting from scheduling j in state s on p cores and try to merge it with an existing state in node 'next'.							
 							new_or_merge_state(*next, *s, j.get_job_index(), predecessors_of(j),
-								st, ftimes, next->get_scheduled_jobs(), successors, predecessors_suspensions, earliest_certain_gang_source_job_disptach(n, *s, j), p);
+								Interval<Time>{_st}, ftimes, next->get_scheduled_jobs(), successors, predecessors_suspensions, earliest_certain_gang_source_job_disptach(n, *s, j), p);
 
 							// make sure we didn't skip any jobs
 							if (be_naive) {

--- a/include/problem.hpp
+++ b/include/problem.hpp
@@ -29,7 +29,7 @@ namespace NP {
 		unsigned int num_processors;
 
 		// Classic default setup: no abort actions
-		Scheduling_problem(Workload jobs, Precedence_constraints prec,
+		Scheduling_problem(const Workload& jobs, const Precedence_constraints& prec,
 		                   unsigned int num_processors = 1)
 		: num_processors(num_processors)
 		, jobs(jobs)
@@ -40,8 +40,8 @@ namespace NP {
 		}
 
 		// Constructor with abort actions and precedence constraints
-		Scheduling_problem(Workload jobs, Precedence_constraints prec,
-		                   Abort_actions aborts,
+		Scheduling_problem(const Workload& jobs, const Precedence_constraints& prec,
+		                   const Abort_actions& aborts,
 		                   unsigned int num_processors)
 		: num_processors(num_processors)
 		, jobs(jobs)
@@ -54,7 +54,7 @@ namespace NP {
 		}
 
 		// Convenience constructor: no DAG, no abort actions
-		Scheduling_problem(Workload jobs,
+		Scheduling_problem(const Workload& jobs,
 		                   unsigned int num_processors = 1)
 		: jobs(jobs)
 		, num_processors(num_processors)

--- a/src/tests/aborts.cpp
+++ b/src/tests/aborts.cpp
@@ -1,0 +1,113 @@
+#include "doctest.h"
+
+#include <iostream>
+#include <sstream>
+
+#include "problem.hpp"
+#include "io.hpp"
+#include "global/space.hpp"
+
+
+using namespace NP;
+
+
+// - basic semantics
+
+const std::string basic_jobs_file =
+"TID, JID, Rmin, Rmax, Cmin, Cmax,  DL, Prio\n"
+"   1,  1,    0,    0,   30,  100, 150,    2\n"
+"   2,  1,    0,    0,    2,    4,  60,    4\n"
+"   3,  1,    0,    0,  100,  100, 100,    1\n"
+"   4,  1,    0,    0,   10,   10,  10,    3\n";
+
+const std::string basic_aborts_file =
+"TID, JID, Tmin, Tmax, Cmin, Cmax\n"
+"  1,   1,   50,   54,    1,    2\n"
+"  3,   1,    5,    5,    0,    0\n"
+"  4,   1,   10,   10,    0,    0\n";
+
+TEST_CASE("[uni] basic aborts") {
+	auto jobs_in = std::istringstream(basic_jobs_file);
+	auto dag_in  = std::istringstream("\n");
+	auto aborts_in = std::istringstream(basic_aborts_file);
+
+	Scheduling_problem<dtime_t> prob{
+		parse_csv_job_file<dtime_t>(jobs_in),
+		parse_precedence_file<dtime_t>(dag_in),
+		parse_abort_file<dtime_t>(aborts_in),
+		1
+	};
+
+	Analysis_options opts;
+	opts.early_exit = false;
+
+	auto space = Global::State_space<dtime_t>::explore(prob, opts);
+	CHECK_FALSE(space->is_schedulable());
+
+	CHECK(space->get_finish_times(prob.jobs[1]).min() == 37);
+	CHECK(space->get_finish_times(prob.jobs[1]).max() == 60);
+
+	delete space;
+};
+
+const std::string cascade_jobs_file =
+"TID, JID, Rmin, Rmax, Cmin, Cmax,  DL, Prio\n"
+"   1,  1,    0,    0,    6,    6,   9,    1\n"
+"   2,  1,   10,   10,    2,    6,  15,    2\n"
+"   3,  1,   16,   16,    3,    6,  23,    3\n"
+"   4,  1,    5,    5,    6,    7,  15,    4\n";
+
+const std::string cascade_aborts_file =
+"TID, JID, Tmin, Tmax, Cmin, Cmax\n"
+"  2,   1,   15,   15,    0,    0\n";
+
+TEST_CASE("[uni] abort stops DL miss cascade") {
+	auto jobs_in = std::istringstream(cascade_jobs_file);
+	auto dag_in  = std::istringstream("\n");
+	auto aborts_in = std::istringstream(cascade_aborts_file);
+
+	Analysis_options opts;
+	opts.early_exit = false;
+
+	SUBCASE("without aborts") {
+		Scheduling_problem<dtime_t> prob{ parse_csv_job_file<dtime_t>(jobs_in)};
+
+		auto space = Global::State_space<dtime_t>::explore(prob, opts);
+		CHECK_FALSE(space->is_schedulable());
+
+		CHECK(space->get_finish_times(prob.jobs[0]).min() == 6);
+		CHECK(space->get_finish_times(prob.jobs[0]).max() == 6);
+		CHECK(space->get_finish_times(prob.jobs[1]).min() == 14);
+		CHECK(space->get_finish_times(prob.jobs[1]).max() == 19);
+		CHECK(space->get_finish_times(prob.jobs[2]).min() == 19);
+		CHECK(space->get_finish_times(prob.jobs[2]).max() == 25);
+		CHECK(space->get_finish_times(prob.jobs[3]).min() == 12);
+		CHECK(space->get_finish_times(prob.jobs[3]).max() == 13);
+
+		delete space;
+	}
+
+	SUBCASE("with aborts") {
+		Scheduling_problem<dtime_t> prob{
+			parse_csv_job_file<dtime_t>(jobs_in),
+			parse_precedence_file<dtime_t>(dag_in),
+			parse_abort_file<dtime_t>(aborts_in),
+			1
+		};
+
+		auto space = Global::State_space<dtime_t>::explore(prob, opts);
+		CHECK(space->is_schedulable());
+
+		CHECK(space->get_finish_times(prob.jobs[0]).min() == 6);
+		CHECK(space->get_finish_times(prob.jobs[0]).max() == 6);
+		CHECK(space->get_finish_times(prob.jobs[1]).min() == 14);
+		CHECK(space->get_finish_times(prob.jobs[1]).max() == 15);
+		CHECK(space->get_finish_times(prob.jobs[2]).min() == 19);
+		CHECK(space->get_finish_times(prob.jobs[2]).max() == 22);
+		CHECK(space->get_finish_times(prob.jobs[3]).min() == 12);
+		CHECK(space->get_finish_times(prob.jobs[3]).max() == 13);
+
+		delete space;
+	}
+
+};


### PR DESCRIPTION
Introduce support for abort action for the multicore analysis.
Add unit tests for abort actions back (NB: unit tests are limited to systems with a single core).