### PR TITLE
Adding several options to the analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ By default the merge level is set to `l1`.
   
 ### Verbose
 
-If the flag `-v` is set when launching an analysis, the tool will show analysis progress in the terminal.
+If the flag `--verbose` is set when launching an analysis, the tool will show the analysis progress in the terminal.
 
 ### Evolution of the SAG width
 

--- a/README.md
+++ b/README.md
@@ -174,13 +174,6 @@ $ cat examples/fig1a.csv | grep -v '3, 9' | build/nptest
 -,  1,  8,  9,  8,  0,  0.000069,  816.000000,  0
 ```
 
-To activate an *idle-time insertion policy* (IIP, see paper for details), use the `-i` option. For example, to use the CW-EDF IIP, pass the `-i CW` option:
-
-```
-$ build/nptest -i CW examples/fig1a.csv 
-examples/fig1a.csv,  1,  9,  10,  9,  0,  0.000121,  848.000000,  0, 1
-```
-
 When analyzing a job set with **dense-time parameters** (i.e., time values specified as floating-point numbers), the option `-t dense` **must** be passed. 
 
 To use the multiprocessor analysis, use the `-m` option. 
@@ -259,6 +252,33 @@ If invoked on an input file named `foo.csv`, the completion times will be stored
 6. WCRT, the worst-case response time (relative to the minimum release time)
 
 Note that the analysis by default aborts after finding the first deadline miss, in which case some of the rows may report nonsensical default values.  To force the analysis to run to completion despite deadline misses, pass the `-c` flag to `nptest`.
+
+## Additional options
+
+### Merge aggressivity
+
+To curb the state space explosion inherent to reachability-based analyses, the SAG merges similar states together. For the analysis of self-suspending tasks and the analysis of multicore systems, merging states may result in losing information and thus reducing the accuracy of the analysis. The `--merge` option allows to define how aggressively should the tool try to merge state. A more aggressive merge reduces runtime but may reduce accuracy. A less aggressive merge may improve accuracy (up to exactness in some cases) but may sometimes have a high cost in terms of runtime.
+
+The option `--merge` can currently be set to 7 different levels:
++ `no`: de-activate merge. This leads to a rapid state-space explosion. It should only be used for very small examples.
++ `c1`: conservative merge level 1. Merge two states only if the availability intervals of one of them are sub-intervals of the other.
++ `c2`: conservative merge level 2. Merge two states only if the availability intervals and job finish time intervals recorded in one of them are sub-intervals of the other.
++ `l1`: lossy level 1. Merge two states if their availability intervals overlap or are contiguous.
++ `l2`; same as `l1` but try to merge up to three states (instead of just two) each time a new state is created.
++ `l3`; same as `l1` but try to merge up to four states (instead of just two) each time a new state is created.
++ `lmax`; same as `l1` but try to merge as many states as possible (instead of just two) each time a new state is created.
+
+By default the merge level is set to `l1`.
+  
+### Verbose
+
+If the flag `-v` is set when launching an analysis, the tool will show analysis progress in the terminal.
+
+### Evolution of the SAG width
+
+The `-r` option reports the response time bounds of every job but also reports the evolution of the width (in terms of nodes) of the SAG for each depth level.
+
+If invoked on an input file named `foo.csv`, the SAG width evolution will be stored in a file named `foo.width.csv`. 
 
 ## Questions, Patches, or Suggestions
 

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -1384,9 +1384,14 @@ namespace NP {
 
 			void explore()
 			{
-				int last_time = get_cpu_time();
-				if (verbose)
+				int last_time;
+				unsigned int target_depth;
+				
+				if (verbose) {
 					std::cout << "0%";
+					last_time = get_cpu_time();
+					target_depth = std::max((unsigned int)jobs.size(), max_depth);
+				}
 
 				make_initial_node(num_cpus);
 
@@ -1416,8 +1421,8 @@ namespace NP {
 
 					if (verbose) {
 						int time = get_cpu_time(); 
-						if (time > last_time) {
-							std::cout << "\r" << (int)(((double)current_job_count / jobs.size()) * 100) << "%";
+						if (time > last_time+4) { // update progress information approxmately every 4 seconds of runtime
+							std::cout << "\r" << (int)(((double)current_job_count / target_depth) * 100) << "%";
 							last_time = time;
 						}
 					}

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -130,7 +130,7 @@ namespace NP {
 				return max_width;
 			}
 
-			const std::vector<unsigned long>& evolution_exploration_front_width() const
+			const std::vector<std::pair<unsigned long, unsigned long>>& evolution_exploration_front_width() const
 			{
 				return width;
 			}
@@ -278,7 +278,7 @@ namespace NP {
 #endif
 			// updated only by main thread
 			unsigned long current_job_count, max_width;
-			std::vector<unsigned long> width;
+			std::vector<std::pair<unsigned long, unsigned long>> width;
 
 #ifdef CONFIG_PARALLEL
 			tbb::enumerable_thread_specific<unsigned long> edge_counter;
@@ -313,7 +313,7 @@ namespace NP {
 				, num_states(0)
 				, num_edges(0)
 				, max_width(0)
-				, width(jobs.size(), 0)
+				, width(jobs.size(), { 0,0 })
 				, rta(jobs.size())
 				, current_job_count(0)
 				, num_cpus(num_cpus)
@@ -966,6 +966,7 @@ namespace NP {
 					target_depth = std::max((unsigned int)state_space_data.num_jobs(), max_depth);
 				}
 
+				int last_num_states = 0;
 				make_initial_node(num_cpus);
 
 				while (current_job_count < state_space_data.num_jobs()) {
@@ -990,7 +991,8 @@ namespace NP {
 
 					// keep track of exploration front width
 					max_width = std::max(max_width, n);
-					width[current_job_count] = n;
+					width[current_job_count] = { n, num_states - last_num_states };
+					last_num_states = num_states;
 
 					if (verbose) {
 						int time = get_cpu_time(); 

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -422,8 +422,18 @@ namespace NP {
 				State& new_s = new_state(std::forward<Args>(args)...);
 
 				// try to merge the new state with existing states in node n.
-				if (!(n.get_states()->empty()) && n.merge_states(new_s, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget))
-					delete& new_s; // if we could merge no need to keep track of the new state anymore
+				if (!(n.get_states()->empty())) {
+					int n_states_merged = n.merge_states(new_s, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
+					if (n_states_merged > 0) {
+						delete& new_s; // if we could merge no need to keep track of the new state anymore
+						num_states -= (n_states_merged - 1);
+					}
+					else
+					{
+						n.add_state(&new_s); // else add the new state to the node
+						num_states++;
+					}
+				}
 				else
 				{
 					n.add_state(&new_s); // else add the new state to the node
@@ -633,9 +643,11 @@ namespace NP {
 							// If we have reached here, it means that we have found an existing node with the same 
 							// set of scheduled jobs than the new state resuting from scheduling job j in system state s.
 							// Thus, our new state can be added to that existing node.
-							if (other->merge_states(st, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget))
+							int num_states_merged = other->merge_states(st, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
+							if (num_states_merged > 1)
 							{
 								delete& st;
+								num_states -= (num_states_merged - 1);
 								return *other;
 							}
 						}
@@ -663,9 +675,11 @@ namespace NP {
 						// If we have reached here, it means that we have found an existing node with the same 
 						// set of scheduled jobs than the new state resuting from scheduling job j in system state s.
 						// Thus, our new state can be added to that existing node.
-						if (other->merge_states(st, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget))
+						int num_states_merged = other->merge_states(st, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
+						if (num_states_merged>0)
 						{
 							delete& st;
+							num_states -= (num_states_merged - 1);
 							return *other;
 						}
 					}

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -916,7 +916,8 @@ namespace NP {
 			// with pending successors must overlap to allow two states to merge. Setting it to true should 
 			// increase accurracy of the analysis but increases runtime significantly.
 			// The 'budget' defines how many states can be merged at once. If 'budget = -1', then there is no limit. 
-			bool merge_states(const Schedule_state<Time>& s, bool conservative, bool useJobFinishTimes = false, int budget = 1)
+			// Returns the number of existing states the new state was merged with.
+			int merge_states(const Schedule_state<Time>& s, bool conservative, bool useJobFinishTimes = false, int budget = 1)
 			{
 				// if we do not use a conservative merge, try to merge with up to 'budget' states if possible.
 				int merge_budget = conservative ? 1 : budget;
@@ -967,7 +968,10 @@ namespace NP {
 					}
 				}
 
-				return result;
+				if (conservative)
+					return result;
+				else
+					return (budget - merge_budget);
 			}
 		};
 

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -30,15 +30,15 @@ namespace NP {
 		{
 		private:
 
-			typedef std::vector<std::pair<Job_index, Interval<Time>>> JobFinishTimes;
-			typedef std::vector<Interval<Time>> CoreAvailability;
+			typedef std::vector<std::pair<Job_index, Interval<Time>>> Job_finish_times;
+			typedef std::vector<Interval<Time>> Core_availability;
 			typedef std::vector<std::pair<const Job<Time>*, Interval<Time>>> Susp_list;
 			typedef std::vector<Susp_list> Successors;
 			typedef std::vector<Susp_list> Predecessors;
 			typedef Interval<unsigned int> Parallelism;
 
 			// system availability intervals
-			CoreAvailability core_avail;
+			Core_availability core_avail;
 
 			// keeps track of the earliest time a job with at least one predecessor is certainly ready and certainly has enough free cores to start executing
 			Time earliest_certain_successor_job_disptach;
@@ -67,7 +67,7 @@ namespace NP {
 			std::vector<Running_job> certain_jobs;
 
 			// job_finish_times holds the finish times of all the jobs that still have an unscheduled successor
-			JobFinishTimes job_finish_times;
+			Job_finish_times job_finish_times;
 
 		public:
 
@@ -155,7 +155,7 @@ namespace NP {
 			// If conservative is false, the a simple overlap or contiguity between inverals is enough.
 			// If conservative is true, then sets `other_in_this` to true if all availability intervals
 			// of other are subintervals of this. Otherwise, `other_in_this` is set to false.
-			bool core_avail_overlap(const CoreAvailability& other, bool conservative, bool& other_in_this) const
+			bool core_avail_overlap(const Core_availability& other, bool conservative, bool& other_in_this) const
 			{
 				assert(core_avail.size() == other.size());
 				other_in_this = false;
@@ -191,12 +191,12 @@ namespace NP {
 			}
 
 			// check if 'other' state can merge with this state
-			bool can_merge_with(const Schedule_state<Time>& other, bool conservative, bool useJobFinishTimes = false) const
+			bool can_merge_with(const Schedule_state<Time>& other, bool conservative, bool use_job_finish_times = false) const
 			{
 				bool other_in_this;
 				if (core_avail_overlap(other.core_avail, conservative, other_in_this))
 				{
-					if (useJobFinishTimes)
+					if (use_job_finish_times)
 						return check_finish_times_overlap(other.job_finish_times, conservative, other_in_this);
 					else
 						return true;
@@ -205,11 +205,11 @@ namespace NP {
 					return false;
 			}
 
-			bool can_merge_with(const CoreAvailability& cav, const JobFinishTimes& jft, bool conservative, bool useJobFinishTimes = false) const
+			bool can_merge_with(const Core_availability& cav, const Job_finish_times& jft, bool conservative, bool use_job_finish_times = false) const
 			{
 				if (core_avail_overlap(cav, conservative))
 				{
-					if (useJobFinishTimes)
+					if (use_job_finish_times)
 						return check_finish_times_overlap(jft, conservative);
 					else
 						return true;
@@ -219,9 +219,9 @@ namespace NP {
 			}
 
 			// first check if 'other' state can merge with this state, then, if yes, merge 'other' with this state.
-			bool try_to_merge(const Schedule_state<Time>& other, bool conservative, bool useJobFinishTimes = false)
+			bool try_to_merge(const Schedule_state<Time>& other, bool conservative, bool use_job_finish_times = false)
 			{
-				if (!can_merge_with(other, conservative, useJobFinishTimes))
+				if (!can_merge_with(other, conservative, use_job_finish_times))
 					return false;
 
 				merge(other.core_avail, other.job_finish_times, other.certain_jobs, other.earliest_certain_successor_job_disptach);
@@ -231,8 +231,8 @@ namespace NP {
 			}
 
 			void merge(
-				const CoreAvailability& cav,
-				const JobFinishTimes& jft,
+				const Core_availability& cav,
+				const Job_finish_times& jft,
 				const std::vector<Running_job>& cert_j,
 				Time ecsj_ready_time)
 			{
@@ -602,10 +602,10 @@ namespace NP {
 			}
 
 			// Check whether the job_finish_times overlap.
-			bool check_finish_times_overlap(const JobFinishTimes& other_ft, bool conservative = false, const bool other_in_this = false) const
+			bool check_finish_times_overlap(const Job_finish_times& other_ft, bool conservative = false, const bool other_in_this = false) const
 			{
-				bool allJobsIntersect = true;
-				// The JobFinishTimes vectors are sorted.
+				bool all_jobs_intersect = true;
+				// The Job_finish_times vectors are sorted.
 				// Check intersect for matching jobs.
 				auto other_it = other_ft.begin();
 				auto state_it = job_finish_times.begin();
@@ -617,19 +617,19 @@ namespace NP {
 						if (conservative) {
 							if (other_in_this == false && !other_it->second.contains(state_it->second))
 							{
-								allJobsIntersect = false; // not all the finish time intervals of this are within those of other
+								all_jobs_intersect = false; // not all the finish time intervals of this are within those of other
 								break;
 							}
 							else if (other_in_this == true && !state_it->second.contains(other_it->second))
 							{
-								allJobsIntersect = false; // not all the finish time intervals of other are within those of this
+								all_jobs_intersect = false; // not all the finish time intervals of other are within those of this
 								break;
 							}
 						}
 						else {
 							if (!other_it->second.intersects(state_it->second))
 							{
-								allJobsIntersect = false;
+								all_jobs_intersect = false;
 								break;
 							}
 						}
@@ -643,12 +643,12 @@ namespace NP {
 					else
 						state_it++;
 				}
-				return allJobsIntersect;
+				return all_jobs_intersect;
 			}
 
-			void widen_finish_times(const JobFinishTimes& from_pwj)
+			void widen_finish_times(const Job_finish_times& from_pwj)
 			{
-				// The JobFinishTimes vectors are sorted.
+				// The Job_finish_times vectors are sorted.
 				// Assume check_overlap() is true.
 				auto from_it = from_pwj.begin();
 				auto state_it = job_finish_times.begin();
@@ -668,7 +668,7 @@ namespace NP {
 				}
 			}
 
-			// Find the offset in the JobFinishTimes vector where the index j should be located.
+			// Find the offset in the Job_finish_times vector where the index j should be located.
 			int jft_find(const Job_index j) const
 			{
 				int start = 0;
@@ -693,7 +693,7 @@ namespace NP {
 		{
 		private:
 
-			typedef typename std::vector<Interval<Time>> CoreAvailability;
+			typedef typename std::vector<Interval<Time>> Core_availability;
 			Time earliest_pending_release;
 			Time next_certain_successor_jobs_disptach;
 			Time next_certain_source_job_release;
@@ -912,12 +912,12 @@ namespace NP {
 			// The option 'conservative' allow a merge of twos states to happen only if the availability 
 			// intervals of one state are constained in the availability intervals of the other state. If
 			// the conservative option is used, the budget parameter is ignored.
-			// The option 'useJobFinishTimes' controls whether or not the job finish time intervals of jobs 
+			// The option 'use_job_finish_times' controls whether or not the job finish time intervals of jobs 
 			// with pending successors must overlap to allow two states to merge. Setting it to true should 
 			// increase accurracy of the analysis but increases runtime significantly.
 			// The 'budget' defines how many states can be merged at once. If 'budget = -1', then there is no limit. 
 			// Returns the number of existing states the new state was merged with.
-			int merge_states(const Schedule_state<Time>& s, bool conservative, bool useJobFinishTimes = false, int budget = 1)
+			int merge_states(const Schedule_state<Time>& s, bool conservative, bool use_job_finish_times = false, int budget = 1)
 			{
 				// if we do not use a conservative merge, try to merge with up to 'budget' states if possible.
 				int merge_budget = conservative ? 1 : budget;
@@ -929,7 +929,7 @@ namespace NP {
 					State* state = *it;
 					if (result == false)
 					{
-						if (state->try_to_merge(s, conservative, useJobFinishTimes))
+						if (state->try_to_merge(s, conservative, use_job_finish_times))
 						{
 							// Update the node finish_time
 							finish_time.widen(s.core_availability());
@@ -951,7 +951,7 @@ namespace NP {
 					}
 					else // if we already merged with one state at least
 					{
-						if (last_state_merged->try_to_merge(*state, conservative, useJobFinishTimes))
+						if (last_state_merged->try_to_merge(*state, conservative, use_job_finish_times))
 						{
 							// the state was merged => we can thus remove the old one from the list of states
 							it = states.erase(it);

--- a/include/problem.hpp
+++ b/include/problem.hpp
@@ -83,6 +83,14 @@ namespace NP {
 		// baseline).
 		bool be_naive;
 
+		// If we use state merging, defines options to use
+		bool merge_conservative;
+		bool merge_use_job_finish_times;
+		int merge_depth;
+
+		// Should we write where we are in the analysis?
+		bool verbose;
+
 		// If using supernodes
 		bool use_supernodes;
 
@@ -91,6 +99,10 @@ namespace NP {
 		, max_depth(0)
 		, early_exit(true)
 		, be_naive(false)
+		, merge_conservative(false)
+		, merge_use_job_finish_times(false)
+		, merge_depth(1)
+		, verbose(false)
 		, use_supernodes(true)
 		{
 		}

--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -382,7 +382,7 @@ int main(int argc, char** argv)
 	      .action("store_const").set_const("1")
 	      .help("store the state graph in Graphviz dot format (default: off)");
 
-	parser.add_option("-v", "--verbose").dest("verbose").set_default("0")
+	parser.add_option("--verbose").dest("verbose").set_default("0")
 		.action("store_const").set_const("1")
 		.help("show the current status of the analysis (default: off)");
 

--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -334,9 +334,9 @@ int main(int argc, char** argv)
 	parser.usage("usage: %prog [OPTIONS]... [JOB SET FILES]...");
 
 	parser.add_option("--merge").dest("merge_opts")
-		.metavar("MERGE-OPTION")
-		.choices({ "no", "c1", "c2", "l1", "l2", "l3", "lmax"}).set_default("l1")
-		.help("choose type of state merging approach used during the analysis. 'no': no merging, 'cx': conservative, 'lx': lossy with depth=x, 'lmax': lossy with max depth (default: l1)");
+		.metavar("MERGE-LEVEL")
+		.choices({ "no", "c1", "c2", "l1", "l2", "l3", "lmax"}).choices({ "no", "c1", "c2","l1","l2","l3","lmax"}).set_default("l1")
+		.help("choose type of state merging approach used during the analysis. 'no': no merging, 'c1': conservative level 1, 'c2': conservative level 2, 'lx': lossy with depth=x, 'lmax': lossy with max depth. (default: l1)");
 
 	parser.add_option("-t", "--time").dest("time_model")
 	      .metavar("TIME-MODEL")

--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -136,11 +136,13 @@ static Analysis_result analyze(
 
 	auto width_stream = std::ostringstream();
 	if (want_width_file) {
-		width_stream << "Depth, Width" << std::endl;
-		const std::vector<unsigned long>& width = space->evolution_exploration_front_width();
+		width_stream << "Depth, Width (#Nodes), Width (#States)" << std::endl;
+		const std::vector<std::pair<unsigned long, unsigned long>>& width = space->evolution_exploration_front_width();
 		for (int d = 0; d < problem.jobs.size(); d++) {
 			width_stream << d << ", "
-					   << width[d] 
+					   << width[d].first
+					   << ", "
+					   << width[d].second
 					   << std::endl;
 		}
 	}


### PR DESCRIPTION
Added several options to the analysis:
* ability to manage the aggressivity of merge with `--merge` option
* verbose option `-v` to show analysis progress on terminal
* added report on the evolution of the width of the graph when using `-r`

Removed the `-n` option as it is now superseded by `--merge`.