### PR TITLE
Ready jobs tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.0)
 
-project(NP_schedulabiliy_test VERSION 3.1.2 LANGUAGES CXX)
+project(NP_schedulabiliy_test VERSION 3.1.3 LANGUAGES CXX)
 
 include_directories(include)
 include_directories(lib/include)

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -573,12 +573,6 @@ namespace NP {
 				}
 			}
 
-			// Check wether a job is ready (not dspatched yet and all its predecessors are completed).
-			bool ready(const Node& n, const Job<Time>& j) const
-			{
-				return n.job_incomplete(j.get_job_index()) && n.job_ready(state_space_data.predecessors_of(j));
-			}
-
 			bool all_jobs_scheduled(const Node& n)
 			{
 				return (n.number_of_scheduled_jobs() == state_space_data.num_jobs());

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -815,7 +815,7 @@ namespace NP {
 					<< "upbnd_t_wc: " << upbnd_t_wc << std::endl);
 
 				//check all jobs that may be eligible to be dispatched next
-				// part 1
+				// part 1: check source jobs (i.e., jobs without prcedence constraints) that are potentially eligible
 				for (auto it = state_space_data.jobs_by_earliest_arrival.lower_bound(t_min);
 					it != state_space_data.jobs_by_earliest_arrival.end();
 					it++)
@@ -836,7 +836,7 @@ namespace NP {
 						continue;
 					found_one |= dispatch(n, j, upbnd_t_wc, t_high_wos);
 				}
-				// part 2
+				// part 2: check ready successor jobs (i.e., jobs with precedence constraints that are completed) that are potentially eligible
 				for (auto it = n.get_ready_successor_jobs().begin();
 					it != n.get_ready_successor_jobs().end();
 					it++)

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -709,7 +709,7 @@ namespace NP {
 								if (nodes_by_key.find(acc, next_key)) {
 									// If be_naive, a new node and a new state should be created for each new job dispatch.
 									if (be_naive) {
-										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
 									else
 									{
@@ -721,13 +721,13 @@ namespace NP {
 											}
 										}
 										if (next == nullptr) {
-											next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+											next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 										}
 									}
 								}
 								if (next == nullptr) {
 									if (nodes_by_key.insert(acc, next_key)) {
-										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
 								}
 								// if we raced with concurrent creation, try again
@@ -736,7 +736,7 @@ namespace NP {
 						// If be_naive, a new node and a new state should be created for each new job dispatch.
 						else if (be_naive) {
 							// note that the accessor should be pointing on something at this point
-							next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+							next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 						}
 						assert(!acc.empty());
 #else

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -52,7 +52,7 @@ namespace NP {
 					std::cout << "Starting" << std::endl;
 
 				State_space* s = new State_space(prob.jobs, prob.prec, prob.aborts, prob.num_processors, 
-					{ opts.merge_conservative, opts.merge_use_job_finish_times, opts.merge_depth }, opts.timeout, opts.max_depth, opts.early_exit, opts.verbose, opts.use_supernodes);
+					{ opts.merge_conservative, opts.merge_use_job_finish_times, opts.merge_depth }, opts.timeout, opts.max_depth, opts.early_exit, opts.verbose);
 				s->be_naive = opts.be_naive;
 				if (opts.verbose)
 					std::cout << "Analysing" << std::endl;
@@ -286,7 +286,6 @@ namespace NP {
 			Processor_clock cpu_time;
 			const double timeout;
 			const unsigned int num_cpus;
-			bool use_supernodes = true;
 
 			State_space_data<Time> state_space_data;
 
@@ -298,8 +297,7 @@ namespace NP {
 				double max_cpu_time = 0,
 				unsigned int max_depth = 0,
 				bool early_exit = true,
-				bool verbose = false,
-				bool use_supernodes = true)
+				bool verbose = false)
 				: state_space_data(jobs, edges, aborts, num_cpus)
 				, aborted(false)
 				, timed_out(false)
@@ -318,7 +316,6 @@ namespace NP {
 				, current_job_count(0)
 				, num_cpus(num_cpus)
 				, early_exit(early_exit)
-				, use_supernodes(use_supernodes)
 #ifdef CONFIG_PARALLEL
 				, partial_rta(jobs.size())
 #endif
@@ -443,8 +440,6 @@ namespace NP {
 
 
 #ifdef CONFIG_PARALLEL
-			//warning  "Parallel code is not updated for supernodes."
-
 			// make node available for fast lookup
 			void insert_cache_node(Nodes_map_accessor& acc, Node_ref n)
 			{
@@ -609,88 +604,6 @@ namespace NP {
 				return { est, lst };
 			}
 
-			// Create a new state st, try to merge st in an existing node. If the merge is unsuccessful, create a new node and add st
-			Node& dispatch_wo_supernodes(const Node& n, const State& s, const Job<Time>& j,
-				const Interval<Time> start_times, const Interval<Time> finish_times, const unsigned int ncores)
-			{
-				// update the set of scheduled jobs
-				Job_set sched_jobs{ n.get_scheduled_jobs(), j.get_job_index() };
-				bool found_match = false;
-				hash_value_t key = n.next_key(j);
-				Node* next_node = NULL;
-#ifdef CONFIG_PARALLEL
-				Nodes_map_accessor acc;
-				while (true)
-				{
-					// check if key exists
-					if (nodes_by_key.find(acc, key))
-					{
-						for (Node_ref other : acc->second)
-						{
-							if (other->get_scheduled_jobs() != sched_jobs)
-								continue;
-
-							next_node = other;
-							break;
-						}
-					}
-					else if (nodes_by_key.insert(acc, key))
-						break;
-
-					// if we raced with concurrent creation, try again
-				}
-#else
-				const auto pair_it = nodes_by_key.find(key);
-				if (pair_it != nodes_by_key.end())
-				{
-					for (Node_ref other : pair_it->second)
-					{
-						if (other->get_scheduled_jobs() != sched_jobs)
-							continue;
-
-						next_node = other;
-						break;
-					}
-				}
-
-#endif
-				State* st = NULL;
-				if (next_node != NULL)
-				{
-					// If we have reached here, it means that we have found an existing node with the same 
-					// set of scheduled jobs than the new state resuting from scheduling job j in system state s.
-					// our new state can be added to that existing node.
-					// create a new state resulting from scheduling j in state s.
-					st = &new_state(s, j.get_job_index(),
-						start_times, finish_times, sched_jobs,
-						next_node->get_jobs_with_pending_successors(), next_node->get_ready_successor_jobs(),
-						state_space_data, n.get_next_certain_source_job_release(), ncores);
-					int num_states_merged = next_node->merge_states(*st, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
-					if (num_states_merged > 0)
-					{
-						delete& st;
-						num_states -= (num_states_merged - 1);
-						return *next_node;
-					}
-				}
-				
-				next_node = &new_node(n, j, j.get_job_index(), state_space_data,
-					state_space_data.earliest_possible_job_release(n, j),
-					state_space_data.earliest_certain_source_job_release(n, j),
-					state_space_data.earliest_certain_sequential_source_job_release(n, j));
-					
-				if (st == NULL) {
-					st = &new_state(s, j.get_job_index(),
-						start_times, finish_times, sched_jobs,
-						next_node->get_jobs_with_pending_successors(), next_node->get_ready_successor_jobs(),
-						state_space_data, n.get_next_certain_source_job_release(), ncores);
-				}
-					
-				next_node->add_state(st);
-				num_states++;
-				return *next_node;
-			}
-
 			Time earliest_job_abortion(const Abort_action<Time>& a)
 			{
 				return a.earliest_trigger_time() + a.least_cleanup_cost();
@@ -783,91 +696,84 @@ namespace NP {
 						// update finish-time estimates
 						update_finish_times(j, ftimes);
 
-						if (use_supernodes == false)
-						{
-							next = &(dispatch_wo_supernodes(n, *s, j, Interval<Time>{_st}, ftimes, p));
-						}
-						else
-						{
 #ifdef CONFIG_PARALLEL
-							// if we do not have a pointer to a node with the same set of scheduled job yet,
-							// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
-							if (next == nullptr || acc.empty())
-							{
-								auto next_key = n.next_key(j);
-								Job_set new_sched_jobs{ n.get_scheduled_jobs(), j.get_job_index() };
+						// if we do not have a pointer to a node with the same set of scheduled job yet,
+						// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
+						if (next == nullptr || acc.empty())
+						{
+							auto next_key = n.next_key(j);
+							Job_set new_sched_jobs{ n.get_scheduled_jobs(), j.get_job_index() };
 
-								while (next == nullptr || acc.empty()) {
-									// check if key exists
-									if (nodes_by_key.find(acc, next_key)) {
-										// If be_naive, a new node and a new state should be created for each new job dispatch.
-										if (be_naive) {
-											next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
-										}
-										else
-										{
-											for (Node_ref other : acc->second) {
-												if (other->get_scheduled_jobs() == new_sched_jobs) {
-													next = other;
-													DM("=== dispatch: next exists." << std::endl);
-													break;
-												}
-											}
-											if (next == nullptr) {
-												next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
-											}
-										}
+							while (next == nullptr || acc.empty()) {
+								// check if key exists
+								if (nodes_by_key.find(acc, next_key)) {
+									// If be_naive, a new node and a new state should be created for each new job dispatch.
+									if (be_naive) {
+										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
-									if (next == nullptr) {
-										if (nodes_by_key.insert(acc, next_key)) {
+									else
+									{
+										for (Node_ref other : acc->second) {
+											if (other->get_scheduled_jobs() == new_sched_jobs) {
+												next = other;
+												DM("=== dispatch: next exists." << std::endl);
+												break;
+											}
+										}
+										if (next == nullptr) {
 											next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 										}
 									}
-									// if we raced with concurrent creation, try again
 								}
+								if (next == nullptr) {
+									if (nodes_by_key.insert(acc, next_key)) {
+										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+									}
+								}
+								// if we raced with concurrent creation, try again
 							}
-							// If be_naive, a new node and a new state should be created for each new job dispatch.
-							else if (be_naive) {
-								// note that the accessor should be pointing on something at this point
-								next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
-							}
-							assert(!acc.empty());
+						}
+						// If be_naive, a new node and a new state should be created for each new job dispatch.
+						else if (be_naive) {
+							// note that the accessor should be pointing on something at this point
+							next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+						}
+						assert(!acc.empty());
 #else
-							// If be_naive, a new node and a new state should be created for each new job dispatch.
-							if (be_naive)
-								next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+						// If be_naive, a new node and a new state should be created for each new job dispatch.
+						if (be_naive)
+							next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 
-							// if we do not have a pointer to a node with the same set of scheduled job yet,
-							// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
-							if (next == nullptr)
-							{
-								const auto pair_it = nodes_by_key.find(n.next_key(j));
-								if (pair_it != nodes_by_key.end()) {
-									Job_set new_sched_jobs{ n.get_scheduled_jobs(), j.get_job_index() };
-									for (Node_ref other : pair_it->second) {
-										if (other->get_scheduled_jobs() == new_sched_jobs)
-										{
-											next = other;
-											DM("=== dispatch: next exists." << std::endl);
-											break;
-										}
+						// if we do not have a pointer to a node with the same set of scheduled job yet,
+						// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
+						if (next == nullptr)
+						{
+							const auto pair_it = nodes_by_key.find(n.next_key(j));
+							if (pair_it != nodes_by_key.end()) {
+								Job_set new_sched_jobs{ n.get_scheduled_jobs(), j.get_job_index() };
+								for (Node_ref other : pair_it->second) {
+									if (other->get_scheduled_jobs() == new_sched_jobs)
+									{
+										next = other;
+										DM("=== dispatch: next exists." << std::endl);
+										break;
 									}
 								}
-								// If there is no node yet, create one.
-								if (next == nullptr)
-									next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 							}
+							// If there is no node yet, create one.
+							if (next == nullptr)
+								next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+						}
 #endif
-							// next should always exist at this point, possibly without states in it
-							// create a new state resulting from scheduling j in state s on p cores and try to merge it with an existing state in node 'next'.							
-							new_or_merge_state(*next, *s, j.get_job_index(),
-								Interval<Time>{_st}, ftimes, next->get_scheduled_jobs(), next->get_jobs_with_pending_successors(), next->get_ready_successor_jobs(), state_space_data, next->get_next_certain_source_job_release(), p);
+						// next should always exist at this point, possibly without states in it
+						// create a new state resulting from scheduling j in state s on p cores and try to merge it with an existing state in node 'next'.							
+						new_or_merge_state(*next, *s, j.get_job_index(),
+							Interval<Time>{_st}, ftimes, next->get_scheduled_jobs(), next->get_jobs_with_pending_successors(), next->get_ready_successor_jobs(), state_space_data, next->get_next_certain_source_job_release(), p);
 
-							// make sure we didn't skip any jobs which would then certainly miss its deadline
-							// only do that if we stop the analysis when a deadline miss is found 
-							if (be_naive && early_exit) {
-								check_for_deadline_misses(n, *next);
-							}
+						// make sure we didn't skip any jobs which would then certainly miss its deadline
+						// only do that if we stop the analysis when a deadline miss is found 
+						if (be_naive && early_exit) {
+							check_for_deadline_misses(n, *next);
 						}
 
 #ifdef CONFIG_COLLECT_SCHEDULE_GRAPH

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -852,7 +852,7 @@ namespace NP {
 			}
 
 			// try to merge state 's' with up to 'budget' states already recorded in this node. 
-			// The option 'conservative' allow a merge of twos states to happen only if the availability 
+			// The option 'conservative' allow a merge of two states to happen only if the availability 
 			// intervals of one state are constained in the availability intervals of the other state. If
 			// the conservative option is used, the budget parameter is ignored.
 			// The option 'use_job_finish_times' controls whether or not the job finish time intervals of jobs 
@@ -912,7 +912,7 @@ namespace NP {
 				}
 
 				if (conservative)
-					return result;
+					return result ? 1:0;
 				else
 					return (budget - merge_budget);
 			}

--- a/include/global/state_space_data.hpp
+++ b/include/global/state_space_data.hpp
@@ -472,11 +472,6 @@ namespace NP {
 			}
 
 		private:
-			// Check wether a job is ready (not dspatched yet and all its predecessors are completed).
-			bool ready(const Node& n, const Job<Time>& j) const
-			{
-				return n.job_incomplete(j.get_job_index()) && n.job_ready(predecessors_of(j));
-			}
 
 			bool unfinished(const Node& n, const Job<Time>& j) const
 			{

--- a/include/global/state_space_data.hpp
+++ b/include/global/state_space_data.hpp
@@ -100,11 +100,12 @@ namespace NP {
 					}
 					else if (j.get_min_parallelism() == 1) {
 						_sequential_source_jobs_by_latest_arrival.insert({ j.latest_arrival(), &j });
+						_jobs_by_earliest_arrival.insert({ j.earliest_arrival(), &j });
 					}
 					else {
 						_gang_source_jobs_by_latest_arrival.insert({ j.latest_arrival(), &j });
-					}
-					_jobs_by_earliest_arrival.insert({ j.earliest_arrival(), &j });
+						_jobs_by_earliest_arrival.insert({ j.earliest_arrival(), &j });
+					}					
 					_jobs_by_deadline.insert({ j.get_deadline(), &j });
 				}
 
@@ -253,7 +254,7 @@ namespace NP {
 						break; // yep, nothing can lower 'when' at this point
 
 					// j is not relevant if it is already scheduled or not of higher priority
-					if (ready(n, j) && j.higher_priority_than(reference_job))
+					if (unfinished(n, j) && j.higher_priority_than(reference_job))
 					{
 						when = j.latest_arrival();
 						// Jobs are ordered by latest_arrival, so next jobs are later. 
@@ -291,7 +292,7 @@ namespace NP {
 						break; // yep, nothing can lower 'when' at this point
 
 					// j is not relevant if it is already scheduled or not of higher priority
-					if (ready(n, j) && j.higher_priority_than(reference_job))
+					if (unfinished(n, j) && j.higher_priority_than(reference_job))
 					{
 						// if the minimum parallelism of j is more than ncores, then 
 						// for j to be released and have its successors completed 
@@ -331,18 +332,20 @@ namespace NP {
 
 				// a higer priority successor job cannot be ready before 
 				// a job of any priority is released
-				Time t_earliest = n.earliest_job_release();
-				for (auto it = successor_jobs_by_latest_arrival.lower_bound(t_earliest);
-					it != successor_jobs_by_latest_arrival.end(); it++)
+				//Time t_earliest = n.earliest_job_release();
+				//for (auto it = successor_jobs_by_latest_arrival.lower_bound(t_earliest);
+				//	it != successor_jobs_by_latest_arrival.end(); it++)
+				for (auto it = n.get_ready_successor_jobs().begin();
+					it != n.get_ready_successor_jobs().end(); it++)
 				{
-					const Job<Time>& j = *(it->second);
+					const Job<Time>& j = **it;
 
 					// check if we can stop looking
-					if (when < j.latest_arrival())
-						break; // yep, nothing can lower 'when' at this point
+					//if (when < j.latest_arrival())
+					//	break; // yep, nothing can lower 'when' at this point
 
 					// j is not relevant if it is already scheduled or not of higher priority
-					if (ready(n, j) && j.higher_priority_than(reference_job)) {
+					if (j.higher_priority_than(reference_job)) {
 						// does it beat what we've already seen?
 						when = std::min(when,
 							latest_ready_time(s, ready_min, j, reference_job, ncores));
@@ -436,6 +439,14 @@ namespace NP {
 
 				DM("         * No more future releases" << std::endl);
 				return rmax;
+			}
+
+			Time get_earliest_job_arrival() const
+			{
+				if (jobs_by_earliest_arrival.empty())
+					return Time_model::constants<Time>::infinity();
+				else
+					return jobs_by_earliest_arrival.begin()->first;
 			}
 
 			// Find the earliest certain job release of all sequential source jobs

--- a/include/global/state_space_data.hpp
+++ b/include/global/state_space_data.hpp
@@ -145,8 +145,6 @@ namespace NP {
 					auto pred_idx = pred.first->get_job_index();
 					auto pred_susp = pred.second;
 					Interval<Time> ft{ 0, 0 };
-					//if (!s.get_finish_times(pred_idx, ft))
-					//	ft = get_finish_times(jobs[pred_idx]);
 					s.get_finish_times(pred_idx, ft);
 					r.lower_bound(ft.min() + pred_susp.min());
 					r.extend_to(ft.max() + pred_susp.max());
@@ -193,8 +191,6 @@ namespace NP {
 					else
 					{
 						Interval<Time> ft{ 0, 0 };
-						//if (!s.get_finish_times(pred_idx, ft))
-						//	ft = get_finish_times(jobs[pred_idx]);
 						s.get_finish_times(pred_idx, ft);
 						r.lower_bound(ft.min() + pred_susp.min());
 						r.extend_to(ft.max() + pred_susp.max());
@@ -332,17 +328,10 @@ namespace NP {
 
 				// a higer priority successor job cannot be ready before 
 				// a job of any priority is released
-				//Time t_earliest = n.earliest_job_release();
-				//for (auto it = successor_jobs_by_latest_arrival.lower_bound(t_earliest);
-				//	it != successor_jobs_by_latest_arrival.end(); it++)
 				for (auto it = n.get_ready_successor_jobs().begin();
 					it != n.get_ready_successor_jobs().end(); it++)
 				{
 					const Job<Time>& j = **it;
-
-					// check if we can stop looking
-					//if (when < j.latest_arrival())
-					//	break; // yep, nothing can lower 'when' at this point
 
 					// j is not relevant if it is already scheduled or not of higher priority
 					if (j.higher_priority_than(reference_job)) {

--- a/include/problem.hpp
+++ b/include/problem.hpp
@@ -91,9 +91,6 @@ namespace NP {
 		// Should we write where we are in the analysis?
 		bool verbose;
 
-		// If using supernodes
-		bool use_supernodes;
-
 		Analysis_options()
 		: timeout(0)
 		, max_depth(0)
@@ -103,7 +100,6 @@ namespace NP {
 		, merge_use_job_finish_times(false)
 		, merge_depth(1)
 		, verbose(false)
-		, use_supernodes(true)
 		{
 		}
 	};

--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -43,8 +43,6 @@ static std::string aborts_file;
 static bool want_multiprocessor = false;
 static unsigned int num_processors = 1;
 
-static bool use_supernodes = true;
-
 #ifdef CONFIG_COLLECT_SCHEDULE_GRAPH
 static bool want_dot_graph;
 #endif
@@ -104,7 +102,6 @@ static Analysis_result analyze(
 	opts.merge_conservative = merge_conservative;
 	opts.merge_depth = merge_depth;
 	opts.merge_use_job_finish_times = merge_use_job_finish_times;
-	opts.use_supernodes = use_supernodes;
 
 	// Actually call the analysis engine
 	auto space = Space::explore(problem, opts);
@@ -392,9 +389,6 @@ int main(int argc, char** argv)
 		.action("store_const").set_const("1")
 		.help("show the current status of the analysis (default: off)");
 
-	parser.add_option("--sn", "--use-supernodes").dest("sn").set_default("1")
-	      .help("use supernodes while buildidng the graph (default: on)");
-
 	parser.add_option("-r", "--report").dest("rta").set_default("0")
 	      .action("store_const").set_const("1")
 	      .help("Reporting: store the best- and worst-case response times and store the evolution of the width of the graph (default: off)");
@@ -482,8 +476,6 @@ int main(int argc, char** argv)
 	want_verbose = options.get("verbose");
 
 	continue_after_dl_miss = options.get("go_on_after_dl");
-
-	use_supernodes = options.get("sn");
 
 #ifdef CONFIG_COLLECT_SCHEDULE_GRAPH
 	want_dot_graph = options.get("dot");


### PR DESCRIPTION
Improves runtime of the SAG analysis for jobs with precedence constraints and/or suspensions by trading a bit of memory for time.
- remembers the set of jobs that have all their precedence completed in nodes to avoid recomputing that set multiple times during the state space exploration.
- calculates and remember the set of dispatched jobs with pending successors when creating a node to not have to recompute it in every state (required to build the set of finishing times saved in each state).

Additionally, this update removes the option to deactivate supernodes to simplify code maintenance