### PR TITLE
Add reconfiguration agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,8 @@ add_executable(nptest ${NPTEST_SOURCES})
 target_link_libraries(nptest ${CORE_LIBS})
 target_link_libraries(runtests ${CORE_LIBS})
 
-target_compile_features(runtests PUBLIC cxx_std_14)
-target_compile_features(nptest PUBLIC cxx_std_14)
+target_compile_features(runtests PUBLIC cxx_std_17)
+target_compile_features(nptest PUBLIC cxx_std_17)
 
 if (MSVC)
     target_compile_options(runtests PUBLIC "/Zc:__cplusplus")

--- a/include/reconfiguration/agent.hpp
+++ b/include/reconfiguration/agent.hpp
@@ -1,0 +1,43 @@
+#ifndef RECONFIGURATION_AGENT_H
+#define RECONFIGURATION_AGENT_H
+
+#include "attachment.hpp"
+#include "global/state.hpp"
+#include "jobs.hpp"
+
+namespace NP::Reconfiguration {
+	template <class Time> class Agent {
+	public:
+		virtual ~Agent() = default;
+
+		virtual Attachment* create_initial_node_attachment() { return nullptr; }
+
+		virtual Attachment* create_next_node_attachment(
+				const Global::Schedule_node<Time> &parent_node, Job<Time> next_job
+		) { return nullptr; }
+
+		virtual void merge_node_attachments(
+				Global::Schedule_node<Time>* destination_node,
+				const Global::Schedule_node<Time> &parent_node,
+				Job<Time> next_job
+		) { }
+
+		virtual void missed_deadline(const Global::Schedule_node<Time> &failed_node, const Job<Time> &late_job) { }
+
+		virtual void encountered_dead_end(const Global::Schedule_node<Time> &dead_node) { }
+
+		virtual void mark_as_leaf_node(const Global::Schedule_node<Time> &leaf_node) { }
+
+		virtual bool allow_merge(
+				const Global::Schedule_node<Time> &parent_node,
+				const Job<Time> &taken_job,
+				const Global::Schedule_node<Time> &destination_node
+		) {
+			return true;
+		}
+
+		virtual bool should_explore(const Global::Schedule_node<Time> &node) { return true; }
+	};
+}
+
+#endif

--- a/include/reconfiguration/attachment.hpp
+++ b/include/reconfiguration/attachment.hpp
@@ -1,0 +1,10 @@
+#ifndef RECONFIGURATION_ATTACHMENT_H
+#define RECONFIGURATION_ATTACHMENT_H
+
+namespace NP::Reconfiguration {
+	struct Attachment {
+		virtual ~Attachment() = default;
+	};
+}
+
+#endif


### PR DESCRIPTION
This PR adds an optional `Reconfiguration_agent` that can be injected into the SAG exploration. This agent can be used to store additional information, and possibly reduce the search space.

`Reconfiguration_agent` itself is an 'abstract' class, and the default implementations of its methods don't manipulate the SAG exploration. Its purpose is that we can create subclasses of `Reconfiguration_agent` that do useful things. For instance, in my fork, I have a subclass that captures the exploration graph, and assigns a rating to each node. (But this will come in a future PR.)

I designed it as an abstract class because it avoids the need to add more code to the actual exploration code (which is already too complicated in my opinion).