### PR TITLE
Add job dispatch ordering constraints

### DIFF
--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -30,9 +30,18 @@ namespace NP {
 		{
 		private:
 
-			typedef std::vector<std::pair<Job_index, Interval<Time>>> Job_finish_times;
+			struct Single_job_times {
+				Job_index job_index;
+				Interval<Time> start_times;
+				Interval<Time> finish_times;
+
+				Single_job_times( // This constructor should be superfluous after updating clang to 16+, but we aren't there yet
+					Job_index job_index, Interval<Time> start_times, Interval<Time> finish_times
+				) : job_index(job_index), start_times(start_times), finish_times(finish_times) {}
+			};
+			typedef std::vector<Single_job_times> Job_times;
 			typedef std::vector<Interval<Time>> Core_availability;
-			typedef std::vector<std::pair<const Job<Time>*, Interval<Time>>> Susp_list;
+			typedef typename State_space_data<Time>::Suspensions_list Susp_list;
 			typedef std::vector<Susp_list> Successors;
 			typedef std::vector<Susp_list> Predecessors;
 			typedef Interval<unsigned int> Parallelism;
@@ -66,8 +75,8 @@ namespace NP {
 			// imprecise set of certainly running jobs, on how many cores they run, and when they should finish
 			std::vector<Running_job> certain_jobs;
 
-			// job_finish_times holds the finish times of all the jobs that still have an unscheduled successor
-			Job_finish_times job_finish_times;
+			// job_times holds the start & finish times of all the jobs that still have an unscheduled successor
+			Job_times job_times;
 
 		public:
 
@@ -106,8 +115,8 @@ namespace NP {
 
 				assert(core_avail.size() > 0);
 
-				// save the job finish time of every job with a successor that is not executed yet in the current state
-				update_job_finish_times(from, j, start_times, finish_times, jobs_with_pending_succ);
+				// save the job start & finish time of every job with a successor that is not executed yet in the current state
+				update_job_times(from, j, start_times, finish_times, jobs_with_pending_succ);
 
 				// NOTE: must be done after the finish times and core availabilities have been updated
 				updated_earliest_certain_successor_job_disptach(ready_succ_jobs, predecessors_of);
@@ -131,17 +140,27 @@ namespace NP {
 				return core_avail[0].min();
 			}
 
-			bool get_finish_times(Job_index j, Interval<Time>& ftimes) const
+			void get_finish_times(Job_index j, Interval<Time>& ftimes) const
 			{
 				int offset = jft_find(j);
-				if (offset < job_finish_times.size() && job_finish_times[offset].first == j)
+				if (offset < job_times.size() && job_times[offset].job_index == j)
 				{
-					ftimes = job_finish_times[offset].second;
-					return true;
+					ftimes = job_times[offset].finish_times;
 				}
 				else {
 					ftimes = Interval<Time>{ 0, Time_model::constants<Time>::infinity() };
-					return false;
+				}
+			}
+
+			void get_start_times(Job_index j, Interval<Time>& ftimes) const
+			{
+				int offset = jft_find(j);
+				if (offset < job_times.size() && job_times[offset].job_index == j)
+				{
+					ftimes = job_times[offset].start_times;
+				}
+				else {
+					ftimes = Interval<Time>{ 0, Time_model::constants<Time>::infinity() };
 				}
 			}
 
@@ -203,7 +222,7 @@ namespace NP {
 				if (core_avail_overlap(other.core_avail, conservative, other_in_this))
 				{
 					if (use_job_finish_times)
-						return check_finish_times_overlap(other.job_finish_times, conservative, other_in_this);
+						return check_finish_times_overlap(other.job_times, conservative, other_in_this);
 					else
 						return true;
 				}
@@ -211,7 +230,7 @@ namespace NP {
 					return false;
 			}
 
-			bool can_merge_with(const Core_availability& cav, const Job_finish_times& jft, bool conservative, bool use_job_finish_times = false) const
+			bool can_merge_with(const Core_availability& cav, const Job_times& jft, bool conservative, bool use_job_finish_times = false) const
 			{
 				if (core_avail_overlap(cav, conservative))
 				{
@@ -230,7 +249,7 @@ namespace NP {
 				if (!can_merge_with(other, conservative, use_job_finish_times))
 					return false;
 
-				merge(other.core_avail, other.job_finish_times, other.certain_jobs, other.earliest_certain_successor_job_disptach);
+				merge(other.core_avail, other.job_times, other.certain_jobs, other.earliest_certain_successor_job_disptach);
 
 				DM("+++ merged " << other << " into " << *this << std::endl);
 				return true;
@@ -238,7 +257,7 @@ namespace NP {
 
 			void merge(
 				const Core_availability& cav,
-				const Job_finish_times& jft,
+				const Job_times& jft,
 				const std::vector<Running_job>& cert_j,
 				Time ecsj_ready_time)
 			{
@@ -269,8 +288,8 @@ namespace NP {
 				// move new certain jobs into the state
 				certain_jobs.swap(new_cj);
 
-				// merge job_finish_times
-				widen_finish_times(jft);
+				// merge job_times
+				widen_start_and_finish_times(jft);
 
 				// update certain ready time of jobs with predecessors
 				earliest_certain_successor_job_disptach = std::max(earliest_certain_successor_job_disptach, ecsj_ready_time);
@@ -458,7 +477,7 @@ namespace NP {
 			}
 
 			// update the list of finish times of jobs with successors w.r.t. the previous system state
-			void update_job_finish_times(const Schedule_state& from,
+			void update_job_times(const Schedule_state& from,
 				Job_index j, Interval<Time> start_times,
 				Interval<Time> finish_times,
 				const std::vector<Job_index>& jobs_with_pending_succ)
@@ -466,22 +485,24 @@ namespace NP {
 				Time lst = start_times.max();
 				Time lft = finish_times.max();
 
-				job_finish_times.reserve(jobs_with_pending_succ.size());
+				job_times.reserve(jobs_with_pending_succ.size());
 
-				auto it = from.job_finish_times.begin();
+				auto it = from.job_times.begin();
 				for (Job_index job : jobs_with_pending_succ)
 				{
 					if (job == j)
-						job_finish_times.emplace_back(job, finish_times);
+						job_times.emplace_back(job, start_times, finish_times);
 					else {
 						// we find the finish time interval of `job` from the previous state. 
 						// Note that if `job` has non-completed successors in the new state,
 						// it must have had non-completed successors in the previous state too, 
 						// thus there is no risk to reach the end iterator
-						while (it->first != job) 
+						while (it->job_index != job)
 							it++;
-						Time job_eft = it->second.min();
-						Time job_lft = it->second.max();
+						Time job_eft = it->finish_times.min();
+						Time job_lft = it->finish_times.max();
+						Time job_est = it->start_times.min();
+						Time job_lst = it->start_times.max();
 						// if there is a single core, then we know that 
 						// jobs that were disptached in the past cannot have 
 						// finished later than when our new job starts executing
@@ -490,7 +511,7 @@ namespace NP {
 							if (job_lft > lst)
 								job_lft = lst;
 						}
-						job_finish_times.emplace_back(job, Interval<Time>{ job_eft, job_lft });
+						job_times.emplace_back(job, Interval<Time>{ job_est, job_lst }, Interval<Time>{ job_eft, job_lft });
 					}
 				}
 			}
@@ -507,10 +528,10 @@ namespace NP {
 					Time ready_time = std::max(avail, rj->latest_arrival());
 					for (const auto& pred : predecessors_of[rj->get_job_index()])
 					{
-						auto from_job = pred.first->get_job_index();
 						Interval<Time> ftimes(0, 0);
-						get_finish_times(from_job, ftimes);
-						Time susp_max = pred.second.max();
+						if (pred.signal_at_completion) get_finish_times(pred.job->get_job_index(), ftimes);
+						else get_start_times(pred.job->get_job_index(), ftimes);
+						Time susp_max = pred.suspension.max();
 						ready_time = std::max(ready_time, ftimes.max() + susp_max);
 					}
 					earliest_certain_successor_job_disptach =
@@ -518,33 +539,33 @@ namespace NP {
 				}
 			}
 
-			// Check whether the job_finish_times overlap.
-			bool check_finish_times_overlap(const Job_finish_times& other_ft, bool conservative = false, const bool other_in_this = false) const
+			// Check whether the job_finish_times overlap. TODO maybe also check whether start times overlap?
+			bool check_finish_times_overlap(const Job_times& other_ft, bool conservative = false, const bool other_in_this = false) const
 			{
 				bool all_jobs_intersect = true;
-				// The Job_finish_times vectors are sorted.
+				// The Job_times vectors are sorted.
 				// Check intersect for matching jobs.
 				auto other_it = other_ft.begin();
-				auto state_it = job_finish_times.begin();
+				auto state_it = job_times.begin();
 				while (other_it != other_ft.end() &&
-					state_it != job_finish_times.end())
+					state_it != job_times.end())
 				{
-					if (other_it->first == state_it->first)
+					if (other_it->job_index == state_it->job_index)
 					{
 						if (conservative) {
-							if (other_in_this == false && !other_it->second.contains(state_it->second))
+							if (other_in_this == false && !other_it->finish_times.contains(state_it->finish_times))
 							{
 								all_jobs_intersect = false; // not all the finish time intervals of this are within those of other
 								break;
 							}
-							else if (other_in_this == true && !state_it->second.contains(other_it->second))
+							else if (other_in_this == true && !state_it->finish_times.contains(other_it->finish_times))
 							{
 								all_jobs_intersect = false; // not all the finish time intervals of other are within those of this
 								break;
 							}
 						}
 						else {
-							if (!other_it->second.intersects(state_it->second))
+							if (!other_it->finish_times.intersects(state_it->finish_times))
 							{
 								all_jobs_intersect = false;
 								break;
@@ -555,7 +576,7 @@ namespace NP {
 					}
 					else if (conservative)
 						return false; // the list of finish time intervals do not match
-					else if (other_it->first < state_it->first)
+					else if (other_it->job_index < state_it->job_index)
 						other_it++;
 					else
 						state_it++;
@@ -563,43 +584,36 @@ namespace NP {
 				return all_jobs_intersect;
 			}
 
-			void widen_finish_times(const Job_finish_times& from_pwj)
+			void widen_start_and_finish_times(const Job_times& from_pwj)
 			{
-				// The Job_finish_times vectors are sorted.
+				// The Job_times vectors are sorted.
 				// Assume check_overlap() is true.
 				auto from_it = from_pwj.begin();
-				auto state_it = job_finish_times.begin();
+				auto state_it = job_times.begin();
 				while (from_it != from_pwj.end() &&
-					state_it != job_finish_times.end())
+					state_it != job_times.end())
 				{
-					if (from_it->first == state_it->first)
+					if (from_it->job_index == state_it->job_index)
 					{
-						state_it->second.widen(from_it->second);
+						state_it->start_times.widen(from_it->start_times);
+						state_it->finish_times.widen(from_it->finish_times);
 						from_it++;
 						state_it++;
 					}
-					else if (from_it->first < state_it->first)
+					else if (from_it->job_index < state_it->job_index)
 						from_it++;
 					else
 						state_it++;
 				}
 			}
 
-			// Find the offset in the Job_finish_times vector where the index j should be located.
+			// Find the offset in the Job_times vector where the index j should be located.
 			int jft_find(const Job_index j) const
 			{
-				int start = 0;
-				int end = job_finish_times.size();
-				while (start < end) {
-					int mid = (start + end) / 2;
-					if (job_finish_times[mid].first == j)
-						return mid;
-					else if (job_finish_times[mid].first < j)
-						start = mid + 1;  // mid is too small, mid+1 might fit.
-					else
-						end = mid;
-				}
-				return start;
+				const Single_job_times dummy_search_times(j, Interval<Time>(), Interval<Time>());
+				return std::lower_bound(job_times.begin(), job_times.end(), dummy_search_times, [](const Single_job_times &a, const Single_job_times &b) {
+					return a.job_index < b.job_index;
+				}) - job_times.begin();
 			}
 
 			// no accidental copies
@@ -611,7 +625,7 @@ namespace NP {
 		private:
 
 			typedef typename std::vector<Interval<Time>> Core_availability;
-			typedef std::vector<std::pair<const Job<Time>*, Interval<Time>>> Susp_list;
+			typedef typename State_space_data<Time>::Suspensions_list Susp_list;
 			typedef std::vector<Susp_list> Successors;
 			typedef std::vector<Susp_list> Predecessors;
 
@@ -931,9 +945,9 @@ namespace NP {
 				for (const auto& succ : successors_of[j])
 				{
 					bool ready = true;
-					for (const auto& pred : predecessors_of[succ.first->get_job_index()])
+					for (const auto& pred : predecessors_of[succ.job->get_job_index()])
 					{
-						auto from_job = pred.first->get_job_index();
+						auto from_job = pred.job->get_job_index();
 						if (from_job != j && !scheduled_jobs.contains(from_job))
 						{
 							ready = false;
@@ -941,7 +955,7 @@ namespace NP {
 						}
 					}
 					if (ready)
-						ready_successor_jobs.push_back(succ.first);
+						ready_successor_jobs.push_back(succ.job);
 				}
 			}
 
@@ -963,7 +977,7 @@ namespace NP {
 
 					bool successor_pending = false;
 					for (const auto& succ : successors_of[job]) {
-						auto to_job = succ.first->get_job_index();
+						auto to_job = succ.job->get_job_index();
 						if (!scheduled_jobs.contains(to_job))
 						{
 							successor_pending = true;

--- a/include/io.hpp
+++ b/include/io.hpp
@@ -122,6 +122,8 @@ namespace NP {
 	{
 		unsigned long from_tid, from_jid, to_tid, to_jid;
 		Time sus_min=0, sus_max=0;
+		std::string signal_type;
+		bool signal_at_completion = true;
 
 		std::ios_base::iostate state_before = in.exceptions();
 
@@ -142,11 +144,21 @@ namespace NP {
 			in >> sus_max;
 		}
 
+		next_field(in);
+		if (more_fields_in_line(in))
+		{
+			in >> signal_type;
+			std::transform(signal_type.begin(), signal_type.end(), signal_type.begin(), [](unsigned char c){ return std::tolower(c); });
+			if (signal_type == "start") signal_at_completion = false;
+			else if (signal_type != "completion") throw std::invalid_argument("Unexpecteds Signal At: must be 'start' or 'completion'");
+		}
+
 		in.exceptions(state_before);
 
 		return Precedence_constraint<Time>{JobID{from_jid, from_tid},
 											JobID{to_jid, to_tid},
-		                          			Interval<Time>{sus_min, sus_max}};
+											Interval<Time>{sus_min, sus_max},
+											signal_at_completion};
 	}
 
 	template<class Time>

--- a/include/precedence.hpp
+++ b/include/precedence.hpp
@@ -10,10 +10,12 @@ namespace NP {
 	public:
 		Precedence_constraint(JobID from,
 			JobID to,
-			Interval<Time> sus_times)
+			Interval<Time> sus_times,
+			bool signal_at_completion = true)
 			: from(from)
 			, to(to)
 			, sus_times(sus_times)
+			, signal_at_completion(signal_at_completion)
 		{
 		}
 
@@ -62,6 +64,11 @@ namespace NP {
 			return fromIndex;
 		}
 
+		bool should_signal_at_completion() const
+		{
+			return signal_at_completion;
+		}
+
 	private:
 		JobID from;
 		JobID to;
@@ -69,6 +76,7 @@ namespace NP {
 		Job_index toIndex;
 		Job_index fromIndex;
 		Interval<Time> sus_times;
+		bool signal_at_completion;
 	};
 
 	class InvalidPrecParameter : public std::exception


### PR DESCRIPTION
This PR adds dispatch ordering constraints, which are just precedence constraints, except that the *to* job can start as soon as the *from* job has **started**. (A traditional precedence constraint would only allow the *to* job to start after the *from* job has **finished**.)

To implement dispatch ordering constraints, I added a `signal_at_completion` boolean field to the `Precedence_constraint` struct. By default, this is `true`, which means that it's a classic precedence constraint. When this is `false` however, it is a job dispatch ordering constraint.

Dispatch ordering constraints are a very useful feature for my master thesis (automatically proposing changes such that unschedulable problems become schedulable after implementing them). I have already used them to automatically fix all my small toy problems.