### PR TITLE
Fix failures in Github Actions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -16,9 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         build_type: [Release]
         compiler:
-          - { c_compiler: gcc-10, cpp_compiler: g++-10 }
           - { c_compiler: gcc-11, cpp_compiler: g++-11 }
           - { c_compiler: gcc-12, cpp_compiler: g++-12 }
+          - { c_compiler: gcc-13, cpp_compiler: g++-13 }
+          - { c_compiler: gcc-14, cpp_compiler: g++-14 }
           - { c_compiler: clang, cpp_compiler: clang++ }
         cmake_option:
           - -DPARALLEL_RUN=OFF -DCOLLECT_SCHEDULE_GRAPHS=ON
@@ -42,8 +43,8 @@ jobs:
             compiler: { c_compiler: clang, cpp_compiler: clang++ }
           - os: windows-latest
             cmake_option: -DPARALLEL_RUN=ON
-          - os: macos-latest
-            compiler: { c_compiler: gcc-10, cpp_compiler: g++-10 }
+          - os: ubuntu-latest
+            compiler: { c_compiler: gcc-11, cpp_compiler: g++-11 }
 
 
     steps:

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -1,6 +1,8 @@
 #ifndef INDEX_SET_H
 #define INDEX_SET_H
 
+#include <stdint.h>
+
 namespace NP {
 
 		class Index_set


### PR DESCRIPTION
The Github Actions pipelines broke because some of the actions run on `ubuntu-latest`, and GitHub recently (I think today) started running those on Ubuntu 24.04 instead of Ubuntu 22.04 (and our workflow relies on the presence of e.g. old gcc versions).

This PR fixes the new errors.