### PR TITLE
Fix failures in Github Actions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -19,6 +19,8 @@ jobs:
           - { c_compiler: gcc-10, cpp_compiler: g++-10 }
           - { c_compiler: gcc-11, cpp_compiler: g++-11 }
           - { c_compiler: gcc-12, cpp_compiler: g++-12 }
+          - { c_compiler: gcc-13, cpp_compiler: g++-13 }
+          - { c_compiler: gcc-14, cpp_compiler: g++-14 }
           - { c_compiler: clang, cpp_compiler: clang++ }
         cmake_option:
           - -DPARALLEL_RUN=OFF -DCOLLECT_SCHEDULE_GRAPHS=ON
@@ -63,6 +65,14 @@ jobs:
       run: |
         sudo apt-get -y update
         sudo apt-get -y install libtbb-dev
+
+    - name: Install GCC 10 on Linux
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.compiler.c_compiler == 'gcc-10' }}
+      run: sudo apt install g++-10 gcc-10
+
+    - name: Install GCC 11 on Linux
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.compiler.c_compiler == 'gcc-11' }}
+      run: sudo apt install g++-11 gcc-11
 
     - name: Install dependencies on macOS
       if: ${{ matrix.os == 'macos-latest' }}

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -1,6 +1,8 @@
 #ifndef INDEX_SET_H
 #define INDEX_SET_H
 
+#include <stdint.h>
+
 namespace NP {
 
 		class Index_set


### PR DESCRIPTION
This PR is an (improved?) version of https://github.com/SAG-org/schedule_abstraction-main/pull/10 that keeps the jobs for GCC 10 and 11.

Please merge the one you prefer.