### PR TITLE
Node and state pooling + new version of parallel analysis

### DIFF
--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -18,6 +18,8 @@
 #include "tbb/concurrent_hash_map.h"
 #include "tbb/enumerable_thread_specific.h"
 #include "tbb/parallel_for.h"
+#include <tbb/task.h>
+#include <tbb/concurrent_queue.h>
 #include <atomic>
 #endif
 
@@ -141,15 +143,12 @@ namespace NP {
 				return cpu_time;
 			}
 
-			typedef std::deque<Node*> Nodes;
-			typedef std::deque<State> States;
-
 #ifdef CONFIG_PARALLEL
-			typedef tbb::enumerable_thread_specific< Nodes > Split_nodes;
-			typedef std::deque<Split_nodes> Nodes_storage;
+			typedef tbb::concurrent_queue<Node*> Nodes;
 #else
-			typedef std::deque< Nodes > Nodes_storage;
+			typedef std::deque<Node*> Nodes;
 #endif
+			typedef std::vector< Nodes > Nodes_storage;
 
 #ifdef CONFIG_COLLECT_SCHEDULE_GRAPH
 
@@ -285,6 +284,8 @@ namespace NP {
 
 #ifdef CONFIG_PARALLEL
 			tbb::enumerable_thread_specific<unsigned long> edge_counter;
+			tbb::enumerable_thread_specific<unsigned long> nodes_counter;
+			tbb::enumerable_thread_specific<unsigned long> states_counter;
 #endif
 			Processor_clock cpu_time;
 			const double timeout;
@@ -319,6 +320,11 @@ namespace NP {
 				, current_job_count(0)
 				, num_cpus(num_cpus)
 				, early_exit(early_exit)
+#ifdef CONFIG_COLLECT_SCHEDULE_GRAPH
+				, nodes_storage(jobs.size() + 1)
+#else
+				, nodes_storage(2)
+#endif
 #ifdef CONFIG_PARALLEL
 				, partial_rta(jobs.size())
 #endif
@@ -375,35 +381,38 @@ namespace NP {
 			void make_initial_node(unsigned num_cores)
 			{
 				// construct initial state
-				nodes_storage.emplace_back();
-				Node& n = new_node(num_cores, state_space_data);
+				Node& n = new_node(0, num_cores, state_space_data);
 				State& s = new_state(num_cores, state_space_data);
 				n.add_state(&s);
-				num_states++;
-			}
-
-			Nodes& nodes()
-			{
 #ifdef CONFIG_PARALLEL
-				return nodes_storage.back().local();
+				states_counter.local()++;
 #else
-				return nodes_storage.back();
+				num_states++;
 #endif
 			}
 
+			Nodes& nodes(const int depth = 0)
+			{
+				return nodes_storage[(current_job_count+ depth)% nodes_storage.size()];
+			}
+
 			template <typename... Args>
-			Node_ref alloc_node(Args&&... args)
+			Node_ref alloc_node(const int depth, Args&&... args)
 			{
 				Node_ref n = node_pool.acquire(std::forward<Args>(args)...);
-				nodes().push_back(n);
+#ifdef CONFIG_PARALLEL
+				nodes(depth).push(n);
+#else
+				nodes(depth).push_back(n);
+#endif // CONFIG_PARALLEL
 
 				// make sure we didn't screw up...
 				auto njobs = n->number_of_scheduled_jobs();
-				assert(
+				/*assert(
 					(!njobs && num_states == 0) // initial state
 					|| (njobs == current_job_count + 1) // normal State
 					|| (njobs == current_job_count + 2 && aborted) // deadline miss
-				);
+				);*/
 
 				return n;
 			}
@@ -426,18 +435,30 @@ namespace NP {
 					int n_states_merged = n.merge_states(new_s, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
 					if (n_states_merged > 0) {
 						release_state(&new_s); // if we could merge no need to keep track of the new state anymore
+#ifdef CONFIG_PARALLEL
+						states_counter.local() -= (n_states_merged - 1);
+#else
 						num_states -= (n_states_merged - 1);
+#endif
 					}
 					else
 					{
 						n.add_state(&new_s); // else add the new state to the node
+#ifdef CONFIG_PARALLEL
+						states_counter.local()++;
+#else
 						num_states++;
+#endif
 					}
 				}
 				else
 				{
 					n.add_state(&new_s); // else add the new state to the node
+#ifdef CONFIG_PARALLEL
+					states_counter.local()++;
+#else
 					num_states++;
+#endif
 				}
 			}
 
@@ -463,22 +484,26 @@ namespace NP {
 			}
 
 			template <typename... Args>
-			Node& new_node_at(Nodes_map_accessor& acc, Args&&... args)
+			Node& new_node_at(const int depth, Nodes_map_accessor& acc, Args&&... args)
 			{
 				assert(!acc.empty());
-				Node_ref n = alloc_node(std::forward<Args>(args)...);
+				Node_ref n = alloc_node(depth, std::forward<Args>(args)...);
 				DM("new node - global " << n << std::endl);
 				// add node to nodes_by_key map.
 				insert_cache_node(acc, n);
+#ifdef CONFIG_PARALLEL
+				nodes_counter.local()++;
+#else
 				num_nodes++;
+#endif
 				return *n;
 			}
 
 			template <typename... Args>
-			Node& new_node(Args&&... args)
+			Node& new_node(const int depth, Args&&... args)
 			{
 				Nodes_map_accessor acc;
-				Node_ref n = alloc_node(std::forward<Args>(args)...);
+				Node_ref n = alloc_node(depth, std::forward<Args>(args)...);
 				while (true) {
 					if (nodes_by_key.find(acc, n->get_key()) || nodes_by_key.insert(acc, n->get_key())) {
 						DM("new node - global " << n << std::endl);
@@ -504,9 +529,9 @@ namespace NP {
 			}
 
 			template <typename... Args>
-			Node& new_node(Args&&... args)
+			Node& new_node(const int depth, Args&&... args)
 			{
-				Node_ref n = alloc_node(std::forward<Args>(args)...);
+				Node_ref n = alloc_node(depth, std::forward<Args>(args)...);
 				DM("new node - global " << n << std::endl);
 				// add node to nodes_by_key map.
 				cache_node(n);
@@ -559,11 +584,15 @@ namespace NP {
 								// create a dummy node for explanation purposes
 								auto frange = new_n.get_last_state()->core_availability(pmin) + j.get_cost(pmin);
 								Node& next =
-									new_node(new_n, j, j.get_job_index(), state_space_data, 0, 0, 0);
+									new_node(1, new_n, j, j.get_job_index(), state_space_data, 0, 0, 0);
 								//const CoreAvailability empty_cav = {};
 								State& next_s = new_state(*new_n.get_last_state(), j.get_job_index(), frange, frange, new_n.get_scheduled_jobs(), new_n.get_jobs_with_pending_successors(), new_n.get_ready_successor_jobs(), state_space_data, new_n.get_next_certain_source_job_release(), pmin);
 								next.add_state(&next_s);
+#ifdef CONFIG_PARALLEL
+								states_counter.local()++;
+#else
 								num_states++;
+#endif
 
 								// update response times
 								update_finish_times(j, frange);
@@ -710,7 +739,7 @@ namespace NP {
 						update_finish_times(j, ftimes);
 
 #ifdef CONFIG_PARALLEL
-						// if we do not have a pointer to a node with the same set of scheduled job yet,
+						// if we do not have a pointer to a node with the same set of scheduled jobs yet,
 						// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
 						if (next == nullptr || acc.empty())
 						{
@@ -722,7 +751,7 @@ namespace NP {
 								if (nodes_by_key.find(acc, next_key)) {
 									// If be_naive, a new node and a new state should be created for each new job dispatch.
 									if (be_naive) {
-										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+										next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
 									else
 									{
@@ -734,13 +763,13 @@ namespace NP {
 											}
 										}
 										if (next == nullptr) {
-											next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+											next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 										}
 									}
 								}
 								if (next == nullptr) {
 									if (nodes_by_key.insert(acc, next_key)) {
-										next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+										next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
 								}
 								// if we raced with concurrent creation, try again
@@ -749,13 +778,13 @@ namespace NP {
 						// If be_naive, a new node and a new state should be created for each new job dispatch.
 						else if (be_naive) {
 							// note that the accessor should be pointing on something at this point
-							next = &(new_node_at(acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+							next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 						}
 						assert(!acc.empty());
 #else
 						// If be_naive, a new node and a new state should be created for each new job dispatch.
 						if (be_naive)
-							next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+							next = &(new_node(1, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 
 						// if we do not have a pointer to a node with the same set of scheduled job yet,
 						// try to find an existing node with the same set of scheduled jobs. Otherwise, create one.
@@ -775,7 +804,7 @@ namespace NP {
 							}
 							// If there is no node yet, create one.
 							if (next == nullptr)
-								next = &(new_node(n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+								next = &(new_node(1, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 						}
 #endif
 						// next should always exist at this point, possibly without states in it
@@ -900,26 +929,21 @@ namespace NP {
 
 				int last_num_states = 0;
 				make_initial_node(num_cpus);
+				tbb::task_group tg;
 
 				while (current_job_count < state_space_data.num_jobs()) {
-					unsigned long n;
-#ifdef CONFIG_PARALLEL
-					const auto& new_nodes_part = nodes_storage.back();
-					n = 0;
-					for (const Nodes& new_nodes : new_nodes_part) {
-						n += new_nodes.size();
-					}
-#else
 					Nodes& exploration_front = nodes();
-					n = exploration_front.size();
+					unsigned long n = 
+#ifdef CONFIG_PARALLEL
+						exploration_front.unsafe_size();
+#else
+						exploration_front.size();
 #endif
 					if (n == 0)
 					{
 						aborted = true;
 						break;
 					}
-					// allocate node space for next depth
-					nodes_storage.emplace_back();
 
 					// keep track of exploration front width
 					max_width = std::max(max_width, n);
@@ -940,19 +964,23 @@ namespace NP {
 						break;
 
 #ifdef CONFIG_PARALLEL
-
-					parallel_for(new_nodes_part.range(),
-						[&](typename Split_nodes::const_range_type& r) {
-							for (auto it = r.begin(); it != r.end(); it++) {
-								const Nodes& new_nodes = *it;
-								auto s = new_nodes.size();
-								tbb::parallel_for(tbb::blocked_range<size_t>(0, s),
-									[&](const tbb::blocked_range<size_t>& r) {
-										for (size_t i = r.begin(); i != r.end(); i++)
-											explore(new_nodes[i]);
-									});
+					Node_ref node;
+					while (exploration_front.try_pop(node)) {
+						tg.run([=] { 
+							explore(*node); 
+#ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
+							// If we don't need to collect all nodes, we can remove
+							// all those that we are done with, which saves a lot of
+							// memory.
+							auto states = node->get_states();
+							for (auto s = states->begin(); s != states->end(); s++) {
+								release_state(*s);
 							}
+							release_node(node);
+#endif
 						});
+					}
+					tg.wait();
 
 #else
 					for (Node_ref n : exploration_front) {
@@ -964,13 +992,11 @@ namespace NP {
 						// If we don't need to collect all nodes, we can remove
 						// all those that we are done with, which saves a lot of
 						// memory.
-#ifndef CONFIG_PARALLEL
 						auto states = n->get_states();
 						for (auto s = states->begin(); s != states->end(); s++ ) {
 							release_state(*s); 
 						}
 						release_node(n); 
-#endif
 #endif
 					}
 #endif
@@ -979,26 +1005,21 @@ namespace NP {
 					if (!be_naive)
 						nodes_by_key.clear();
 
-					current_job_count++;
-
 #ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
 					// If we don't need to collect all nodes, we can remove
 					// all those that we are done with, which saves a lot of
 					// memory.
-#ifdef CONFIG_PARALLEL
-					parallel_for(nodes_storage.front().range(),
-						[](typename Split_nodes::range_type& r) {
-							for (auto it = r.begin(); it != r.end(); it++)
-								it->clear();
-						});
+					nodes().clear();
 #endif
-					nodes_storage.pop_front();
-#endif
-
+					current_job_count++;
 				}
 				if (verbose)
 					std::cout << "\r100%" << std::endl << "Terminating" << std::endl;
 
+#ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
+				// clean out any remaining nodes
+				nodes_storage.clear();
+#endif
 #ifdef CONFIG_PARALLEL
 				// propagate any updates to the response-time estimates
 				for (auto& r : partial_rta) {
@@ -1007,26 +1028,13 @@ namespace NP {
 							update_finish_times(rta, i, r[i].rt);
 					}
 				}
-#endif
 
-
-#ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
-				// clean out any remaining nodes
-				while (!nodes_storage.empty()) {
-#ifdef CONFIG_PARALLEL
-					parallel_for(nodes_storage.front().range(),
-						[](typename Split_nodes::range_type& r) {
-							for (auto it = r.begin(); it != r.end(); it++)
-								it->clear();
-						});
-#endif
-					nodes_storage.pop_front();
-				}
-#endif
-
-#ifdef CONFIG_PARALLEL
 				for (auto& c : edge_counter)
 					num_edges += c;
+				for (auto& c : nodes_counter)
+					num_nodes += c;
+				for (auto& c : states_counter)
+					num_states += c;
 #endif
 			}
 

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -747,22 +747,15 @@ namespace NP {
 							while (next == nullptr || acc.empty()) {
 								// check if key exists
 								if (nodes_by_key.find(acc, next_key)) {
-									// If be_naive, a new node and a new state should be created for each new job dispatch.
-									if (be_naive) {
-										next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
+									for (Node_ref other : acc->second) {
+										if (other->get_scheduled_jobs() == new_sched_jobs) {
+											next = other;
+											DM("=== dispatch: next exists." << std::endl);
+											break;
+										}
 									}
-									else
-									{
-										for (Node_ref other : acc->second) {
-											if (other->get_scheduled_jobs() == new_sched_jobs) {
-												next = other;
-												DM("=== dispatch: next exists." << std::endl);
-												break;
-											}
-										}
-										if (next == nullptr) {
-											next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
-										}
+									if (next == nullptr) {
+										next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
 									}
 								}
 								if (next == nullptr) {
@@ -773,12 +766,6 @@ namespace NP {
 								// if we raced with concurrent creation, try again
 							}
 						}
-						// If be_naive, a new node and a new state should be created for each new job dispatch.
-						/*else if (be_naive) {
-							// note that the accessor should be pointing on something at this point
-							next = &(new_node_at(1, acc, n, j, j.get_job_index(), state_space_data, state_space_data.earliest_possible_job_release(n, j), state_space_data.earliest_certain_source_job_release(n, j), state_space_data.earliest_certain_sequential_source_job_release(n, j)));
-						}
-						assert(!acc.empty());*/
 #else
 						// If be_naive, a new node and a new state should be created for each new job dispatch.
 						if (be_naive)

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -960,12 +960,18 @@ namespace NP {
 						check_cpu_timeout();
 						if (aborted)
 							break;
-
+#ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
+						// If we don't need to collect all nodes, we can remove
+						// all those that we are done with, which saves a lot of
+						// memory.
+#ifndef CONFIG_PARALLEL
 						auto states = n->get_states();
 						for (auto s = states->begin(); s != states->end(); s++ ) {
 							release_state(*s); 
 						}
 						release_node(n); 
+#endif
+#endif
 					}
 #endif
 

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -1039,40 +1039,27 @@ namespace NP {
 				std::map<const Schedule_node<Time>*, unsigned int> node_id;
 				unsigned int i = 0;
 				out << "digraph {" << std::endl;
-#ifdef CONFIG_PARALLEL
-				for (const Split_nodes& nodes : space.get_nodes()) {
-					for (const Schedule_node<Time>& n : tbb::flattened2d<Split_nodes>(nodes)) {
-#else
 				for (const auto& front : space.get_nodes()) {
-					for (const Schedule_node<Time>& n : front) {
-#endif
-						/*node_id[&n] = i++;
-						out << "\tS" << node_id[&n]
-							<< "[label=\"S" << node_id[&n] << ": ";
-						n.print_vertex_label(out, space.jobs);
-						out << "\"];" << std::endl;*/
-						node_id[&n] = i++;
-						out << "\tN" << node_id[&n]
-							<< "[label=\"N" << node_id[&n] << ": {";
-						const auto* n_states = n.get_states();
+					for (auto n : front) {
+						node_id[n] = i++;
+						out << "\tN" << node_id[n]
+							<< "[label=\"N" << node_id[n] << ": {";
+						const auto* n_states = n->get_states();
 
 						for (State* s : *n_states)
 						{
 							out << "[";
 							s->print_vertex_label(out, space.state_space_data.jobs);
-							//<< s->earliest_finish_time()
-							//<< ", "
-							//<< s->latest_finish_time()
 							out << "]\\n";
 						}
 						out << "}"
 							<< "\\nER=";
-						if (n.earliest_job_release() ==
+						if (n->earliest_job_release() ==
 							Time_model::constants<Time>::infinity()) {
 							out << "N/A";
 						}
 						else {
-							out << n.earliest_job_release();
+							out << n->earliest_job_release();
 						}
 						out << "\"];"
 							<< std::endl;

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -430,7 +430,9 @@ namespace NP {
 				// create a new state.
 				State& new_s = new_state(std::forward<Args>(args)...);
 				// try to merge the new state with existing states in node n.
-				//if (!(n.get_states()->empty())) {
+#ifndef CONFIG_PARALLEL
+				if (!(n.get_states()->empty())) {
+#endif
 					int n_states_merged = n.merge_states(new_s, merge_opts.conservative, merge_opts.use_finish_times, merge_opts.budget);
 					if (n_states_merged > 0) {
 						release_state(&new_s); // if we could merge no need to keep track of the new state anymore
@@ -449,16 +451,15 @@ namespace NP {
 						num_states++;
 #endif
 					}
-				/* }
+#ifndef CONFIG_PARALLEL
+				}
 				else
 				{
 					n.add_state(&new_s); // else add the new state to the node
-#ifdef CONFIG_PARALLEL
-					states_counter.local()++;
-#else
 					num_states++;
+
+				}
 #endif
-				}*/
 			}
 
 			void release_state(State* s)

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -760,6 +760,7 @@ namespace NP {
 				num_cpus = num_cores;
 				finish_time = { 0,0 };
 				a_max = 0;
+				scheduled_jobs.clear();
 				num_jobs_scheduled = 0;
 				states.clear();
 				earliest_pending_release = state_space_data.get_earliest_job_arrival();
@@ -781,8 +782,7 @@ namespace NP {
 			)
 			{
 				states.clear();
-				scheduled_jobs = from.scheduled_jobs; 
-				scheduled_jobs.add(idx);
+				scheduled_jobs.set(from.scheduled_jobs, idx);
 				lookup_key = from.next_key(j);
 				num_cpus = from.num_cpus;
 				num_jobs_scheduled = from.num_jobs_scheduled + 1;

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -118,6 +118,54 @@ namespace NP {
 				DM("*** new state: constructed " << *this << std::endl);
 			}
 
+			// initial state -- nothing yet has finished, nothing is running
+			void reset(const unsigned int num_processors, const State_space_data<Time>& state_space_data)
+			{
+				core_avail = Core_availability(num_processors, Interval<Time>(Time(0), Time(0)));
+				earliest_certain_successor_job_disptach = Time_model::constants<Time>::infinity();
+				earliest_certain_gang_source_job_disptach = state_space_data.get_earliest_certain_gang_source_job_release();
+				assert(core_avail.size() > 0);
+			}
+
+			void reset(
+				const Schedule_state& from,
+				Job_index j,
+				Interval<Time> start_times,
+				Interval<Time> finish_times,
+				const Job_set& scheduled_jobs,
+				const std::vector<Job_index>& jobs_with_pending_succ,
+				const std::vector<const Job<Time>*>& ready_succ_jobs,
+				const State_space_data<Time>& state_space_data,
+				Time next_source_job_rel,
+				unsigned int ncores = 1)
+			{
+				const Successors& successors_of = state_space_data.successors_suspensions;
+				const Predecessors& predecessors_of = state_space_data.predecessors_suspensions;
+				const Job_precedence_set& predecessors = state_space_data.predecessors_of(j);
+				// update the set of certainly running jobs and
+				// get the number of cores certainly used by active predecessors
+				certain_jobs.clear();
+				int n_prec = update_certainly_running_jobs_and_get_num_prec(from, j, start_times, finish_times, ncores, predecessors);
+
+				// calculate the cores availability intervals resulting from dispatching job j on ncores in state 'from'
+				core_avail.clear();
+				update_core_avail(from, j, predecessors, n_prec, start_times, finish_times, ncores);
+
+				assert(core_avail.size() > 0);
+
+				// save the job finish time of every job with a successor that is not executed yet in the current state
+				job_finish_times.clear();
+				update_job_finish_times(from, j, start_times, finish_times, jobs_with_pending_succ);
+
+				// NOTE: must be done after the finish times and core availabilities have been updated
+				updated_earliest_certain_successor_job_disptach(ready_succ_jobs, predecessors_of);
+
+				// NOTE: must be done after the core availabilities have been updated
+				update_earliest_certain_gang_source_job_disptach(next_source_job_rel, scheduled_jobs, state_space_data);
+
+				DM("*** new state: constructed " << *this << std::endl);
+			}
+
 			Interval<Time> core_availability(unsigned long p = 1) const
 			{
 				assert(core_avail.size() > 0);
@@ -706,10 +754,49 @@ namespace NP {
 				update_jobs_with_pending_succ(from, idx, state_space_data.successors_suspensions, state_space_data.predecessors_suspensions, this->scheduled_jobs);
 			}
 
-			~Schedule_node()
+			void reset(unsigned int num_cores, const State_space_data<Time>& state_space_data)
 			{
-				for (State* s : states)
-					delete s;
+				lookup_key = 0;
+				num_cpus = num_cores;
+				finish_time = { 0,0 };
+				a_max = 0;
+				num_jobs_scheduled = 0;
+				states.clear();
+				earliest_pending_release = state_space_data.get_earliest_job_arrival();
+				next_certain_successor_jobs_disptach = Time_model::constants<Time>::infinity();
+				next_certain_sequential_source_job_release = state_space_data.get_earliest_certain_seq_source_job_release();
+				next_certain_gang_source_job_disptach = Time_model::constants<Time>::infinity();
+				next_certain_source_job_release = std::min(next_certain_sequential_source_job_release, state_space_data.get_earliest_certain_gang_source_job_release());
+			}
+
+			// transition: new node by scheduling a job 'j' in an existing node 'from'
+			void reset(
+				const Schedule_node& from,
+				const Job<Time>& j,
+				std::size_t idx,
+				const State_space_data<Time>& state_space_data,
+				const Time next_earliest_release,
+				const Time next_certain_source_job_release, // the next time a job without predecessor is certainly released
+				const Time next_certain_sequential_source_job_release // the next time a job without predecessor that can execute on a single core is certainly released
+			)
+			{
+				states.clear();
+				scheduled_jobs = from.scheduled_jobs; 
+				scheduled_jobs.add(idx);
+				lookup_key = from.next_key(j);
+				num_cpus = from.num_cpus;
+				num_jobs_scheduled = from.num_jobs_scheduled + 1;
+				finish_time = {0, Time_model::constants<Time>::infinity()};
+				a_max = Time_model::constants<Time>::infinity();
+				earliest_pending_release = next_earliest_release;
+				this->next_certain_source_job_release = next_certain_source_job_release;
+				next_certain_successor_jobs_disptach = Time_model::constants<Time>::infinity();
+				this->next_certain_sequential_source_job_release = next_certain_sequential_source_job_release;
+				ready_successor_jobs.clear();
+				jobs_with_pending_succ.clear();
+				next_certain_gang_source_job_disptach = Time_model::constants<Time>::infinity();
+				update_ready_successors(from, idx, state_space_data.successors_suspensions, state_space_data.predecessors_suspensions, this->scheduled_jobs);
+				update_jobs_with_pending_succ(from, idx, state_space_data.successors_suspensions, state_space_data.predecessors_suspensions, this->scheduled_jobs);
 			}
 
 			const unsigned int number_of_scheduled_jobs() const

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -29,6 +29,14 @@ namespace NP {
 					the_set[i] = a.the_set[i] & ~b.the_set[i];
 			}
 
+			Index_set& operator=(const Index_set& other)
+			{
+				if (this != &other) {
+					the_set = other.the_set;
+				}
+				return *this;
+			}
+
 			bool operator==(const Index_set &other) const
 			{
 				return the_set == other.the_set;

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -20,6 +20,14 @@ namespace NP {
 				set_bit(idx, true);
 			}
 
+			// derive a new set by "cloning" an existing set and adding an index
+			void set(const Index_set& from, std::size_t idx)
+			{
+				the_set.resize(std::max(from.the_set.size(), (idx / 64) + 1));
+				std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
+				set_bit(idx, true);
+			}
+
 			// create the diff of two job sets (intended for debugging only)
 			Index_set(const Index_set &a, const Index_set &b)
 					: the_set(std::max(a.the_set.size(), b.the_set.size()), 0)
@@ -90,6 +98,11 @@ namespace NP {
 				if (idx / 64 >= the_set.size())
 					the_set.resize((idx / 64) + 1, 0);
 				set_bit(idx, true);
+			}
+
+			void clear()
+			{
+				the_set.clear();
 			}
 
 			friend std::ostream& operator<< (std::ostream& stream,

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -23,6 +23,7 @@ namespace NP {
 			// derive a new set by "cloning" an existing set and adding an index
 			void set(const Index_set& from, std::size_t idx)
 			{
+				the_set.clear();
 				the_set.resize(std::max(from.the_set.size(), (idx / 64) + 1));
 				std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
 				set_bit(idx, true);

--- a/include/object_pool.hpp
+++ b/include/object_pool.hpp
@@ -30,7 +30,7 @@ public:
 
     void release(T* obj) {
 #ifdef CONFIG_PARALLEL
-		pool.push(obj);
+        pool.push(obj);
 #else
         pool.push_back(obj);
 #endif

--- a/include/object_pool.hpp
+++ b/include/object_pool.hpp
@@ -4,27 +4,49 @@
 template <typename T>
 class Object_pool {
 private:
+#ifdef CONFIG_PARALLEL
+	tbb::concurrent_queue<T*> pool;
+#else
     std::deque<T*> pool;
+#endif
 public:
     template <typename... Args>
     T* acquire(Args&&... args) {
+#ifdef CONFIG_PARALLEL
+		T* obj;
+		if (!pool.try_pop(obj)) {
+			return new T(std::forward<Args>(args)...);
+		}
+#else
         if (pool.empty()) {
             return new T(std::forward<Args>(args)...);
         }
         T* obj = pool.back();
         pool.pop_back();
+#endif
         obj->reset(std::forward<Args>(args)...); // Initialize the object
         return obj;
     }
 
     void release(T* obj) {
+#ifdef CONFIG_PARALLEL
+		pool.push(obj);
+#else
         pool.push_back(obj);
+#endif
     }
 
     ~Object_pool() {
+#ifdef CONFIG_PARALLEL
+		T* obj;
+		while (pool.try_pop(obj)) {
+			delete obj;
+		}
+#else
         for (T* obj : pool) {
             delete obj;
         }
+#endif
     }
 };
 

--- a/include/object_pool.hpp
+++ b/include/object_pool.hpp
@@ -1,0 +1,31 @@
+#ifndef OBJECT_POOL
+#define OBJECT_POOL
+
+template <typename T>
+class Object_pool {
+private:
+    std::deque<T*> pool;
+public:
+    template <typename... Args>
+    T* acquire(Args&&... args) {
+        if (pool.empty()) {
+            return new T(std::forward<Args>(args)...);
+        }
+        T* obj = pool.back();
+        pool.pop_back();
+        obj->reset(std::forward<Args>(args)...); // Initialize the object
+        return obj;
+    }
+
+    void release(T* obj) {
+        pool.push_back(obj);
+    }
+
+    ~Object_pool() {
+        for (T* obj : pool) {
+            delete obj;
+        }
+    }
+};
+
+#endif // !OBJECT_POOL

--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -364,10 +364,6 @@ int main(int argc, char** argv)
 	      .help("abort graph exploration after reaching given depth (>= 2)")
 	      .set_default("0");
 
-	/*parser.add_option("-n", "--naive").dest("naive").set_default("0")
-	      .action("store_const").set_const("1")
-	      .help("use the naive exploration method (default: merging)");*/
-
 	parser.add_option("-p", "--precedence").dest("precedence_file")
 	      .help("name of the file that contains the job set's precedence DAG")
 	      .set_default("");
@@ -421,6 +417,13 @@ int main(int argc, char** argv)
 	}
 
 	std::string merge_opts = (const std::string&)options.get("merge_opts");
+#ifdef CONFIG_PARALLEL
+	if (merge_opts == "no") {
+		std::cerr << "Error: parallel analysis (CONFIG_PARALLEL=ON) is incompatible with naive exploration."
+			<< std::endl;
+		return 3;
+	}
+#endif
 	want_naive = (merge_opts == "no");
 	if (merge_opts == "c1") {
 		merge_conservative = true;
@@ -430,7 +433,7 @@ int main(int argc, char** argv)
 		merge_conservative = true;
 		merge_use_job_finish_times = true;
 	}
-	if (merge_opts == "l2")
+	else if (merge_opts == "l2")
 		merge_depth = 2;
 	else if (merge_opts == "l3")
 		merge_depth = 3;
@@ -441,8 +444,6 @@ int main(int argc, char** argv)
 
 	std::string time_model = (const std::string&)options.get("time_model");
 	want_dense = time_model == "dense";
-
-	//want_naive = options.get("naive");
 
 	timeout = options.get("timeout");
 


### PR DESCRIPTION
This pull request contains the following changes:

- object pooling for Node and State objects to avoid deallocating and re-allocating memory for nodes and states all the time;
- a revision of the code parallelization. Specifically:
  - uses tasks and 'tbb::task_group' instead of 'parallel_for' to ensure better load balancing between threads;
  - uses 'concurrent_queue' where possible;
  - avoids node replications between threads;
  - reduces contention on 'node_storage';
  - added a mutex in each Node to avoid race conditions on the updated of 'states';
  - removed atomicity requirement on the variables counting edges, nodes and states, instead counting in each thread independently and summing the local values at the end of the analysis.
  - 
Potential future work: check if parallelizing operations on states in each node may yet improve effective parallelism.