### PR TITLE
Fix unsound suspension analysis

### DIFF
--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -706,7 +706,7 @@ namespace NP {
 						// Calculate t_wc and t_high
 						Time t_wc = std::max(s->core_availability().max(), next_certain_job_ready_time(n, *s));
 
-						Time t_high_succ = state_space_data.next_certain_higher_priority_successor_job_ready_time(n, *s, j, p, t_wc + 1);
+						Time t_high_succ = state_space_data.next_certain_higher_priority_successor_job_ready_time(n, *s, j, p);
 						Time t_high_gang = state_space_data.next_certain_higher_priority_gang_source_job_ready_time(n, *s, j, p, t_wc + 1);
 						Time t_high = std::min(t_high_wos, std::min(t_high_gang, t_high_succ));
 


### PR DESCRIPTION
I believe that the current analysis of precedence constraints with suspensions is unsound. This PR adds 2 test cases:
- The first test case creates an infeasible problem, and `CHECK`s that the analysis reports it as unschedulable. However, the analysis claims that it is schedulable.
- The second test case creates an unschedulable problem, and `CHECK`s that the analysis also reports it as unschedulable. However, the analysis claims that it is schedulable.

I made fixes for this in https://github.com/SAG-org/schedule_abstraction-main/pull/9, but adding these fixes will break other unit tests because the analysis becomes more pessimistic. I might backport these fixes if needed, but preferably not.

The first fix is to insert
```
lst = std::max(lst, state_space_data.latest_ready_time(s, j));
```
after
```
Time lst = std::min(t_wc,
    std::min(t_high, t_avail) - Time_model::constants<Time>::epsilon());
```
in space.hpp.

The second fix is to remove the following unsound code:
```
// skip if part of disregard
if (contains(disregard, pred.first->get_job_index()))
    continue;
```
in state_space_data.hpp.