### PR TITLE
Disregard finished predecessors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.0)
 
-project(NP_schedulabiliy_test VERSION 3.1.5 LANGUAGES CXX)
+project(NP_schedulabiliy_test VERSION 3.1.6 LANGUAGES CXX)
 
 include_directories(include)
 include_directories(lib/include)

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -556,7 +556,7 @@ namespace NP {
 
 			bool unfinished(const Node& n, const Job<Time>& j) const
 			{
-				return n.job_incomplete(j.get_job_index());
+				return n.job_not_dispatched(j.get_job_index());
 			}
 
 			// Check if any job is guaranteed to miss its deadline in any state in node new_n
@@ -731,7 +731,7 @@ namespace NP {
 						Interval<Time> ftimes = calculate_abort_time(j, _st.first, _st.second, eft, lft);
 
 						// yep, job j is a feasible successor in state s
-						dispatched_one = true;						
+						dispatched_one = true;
 
 						// update finish-time estimates
 						update_finish_times(j, ftimes);

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -855,9 +855,14 @@ namespace NP {
 				return scheduled_jobs;
 			}
 
-			const bool job_incomplete(Job_index j) const
+			const bool job_not_dispatched(Job_index j) const
 			{
 				return !scheduled_jobs.contains(j);
+			}
+
+			const bool job_dispatched(Job_index j) const
+			{
+				return scheduled_jobs.contains(j);
 			}
 
 			const bool job_ready(const Job_precedence_set& predecessors) const


### PR DESCRIPTION
Before this commit, the `conditional_latest_ready_time function` is needlessly pessimistic because jobs that are guaranteed to be finished can still postpone the ready times of reference jobs.

This PR will disregard predecessor jobs that must have finished already because at least one of their successors has already been dispatched.

Note: this PR adds the test case `"[global-prec] taskset-21 check transitivity pessimism (5)"`, which causes a 'gap' in the test case numbering. Test cases `ts7` to `ts20` will be provided by my future PRs. (I'm submitting my less complex PRs first.)