### PR TITLE
Reduce conditional_latest_ready_time pessimism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.0)
 
-project(NP_schedulabiliy_test VERSION 3.1.6 LANGUAGES CXX)
+project(NP_schedulabiliy_test VERSION 3.1.7 LANGUAGES CXX)
 
 include_directories(include)
 include_directories(lib/include)


### PR DESCRIPTION
Before this commit, the `conditional_latest_ready_time` function was needlessly pessimistic because predecessor jobs could postpone the latest ready time of `j_high`, even if they are guaranteed to be finished before `j_low` is ready.

We already had a similar optimization for single-core analysis, which is now generalized to multiple cores.