### PR TITLE
Multicore DAG analysis accuracy improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(include)
 include_directories(lib/include)
 
 option(PARALLEL_RUN "Enable parallel run" OFF)
-option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" ON)
+option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" OFF)
 option(USE_JE_MALLOC "Use the Facebook jemalloc scalable memory allocator" OFF)
 option(COLLECT_SCHEDULE_GRAPHS "Enable the collection of schedule graphs (disables parallel)" OFF)
 option(DEBUG "Enable debugging" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(include)
 include_directories(lib/include)
 
 option(PARALLEL_RUN "Enable parallel run" OFF)
-option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" OFF)
+option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" ON)
 option(USE_JE_MALLOC "Use the Facebook jemalloc scalable memory allocator" OFF)
 option(COLLECT_SCHEDULE_GRAPHS "Enable the collection of schedule graphs (disables parallel)" OFF)
 option(DEBUG "Enable debugging" OFF)

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -864,7 +864,7 @@ namespace NP {
 
 					// if its priority is lower than than the minimum priority of the next dispatched job, it will not be dispatched next
 					// (remember that lower number means higher priority)
-					if (j.get_priority() > n.get_min_successor_priority())
+					if (j.get_priority() > n.get_next_dispatched_job_min_priority())
 						continue;
 
 					Time t_high_wos = state_space_data.next_certain_higher_priority_seq_source_job_release(n, j, upbnd_t_wc + 1);
@@ -883,7 +883,7 @@ namespace NP {
 					DM(j << " (" << j.get_job_index() << ")" << std::endl);
 					// if the job priority is lower than than the minimum priority of the next dispatched job, it will not be dispatched next
 					// (remember that lower number means higher priority)
-					if (j.get_priority() > n.get_min_successor_priority())
+					if (j.get_priority() > n.get_next_dispatched_job_min_priority())
 						continue;
 
 					// don't look outside the window of interest

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -847,7 +847,7 @@ namespace NP {
 					<< "upbnd_t_wc: " << upbnd_t_wc << std::endl);
 
 				//check all jobs that may be eligible to be dispatched next
-				// part 1: check source jobs (i.e., jobs without prcedence constraints) that are potentially eligible
+				// part 1: check source jobs (i.e., jobs without precedence constraints) that are potentially eligible
 				for (auto it = state_space_data.jobs_by_earliest_arrival.lower_bound(t_min);
 					it != state_space_data.jobs_by_earliest_arrival.end();
 					it++)
@@ -858,7 +858,13 @@ namespace NP {
 					if (j.earliest_arrival() > upbnd_t_wc)
 						break;
 
+					// if it was dispatched already, it will not be dispatched again
 					if (!unfinished(n, j))
+						continue;
+
+					// if its priority is lower than than the minimum priority of the next dispatched job, it will not be dispatched next
+					// (remember that lower number means higher priority)
+					if (j.get_priority() > n.get_min_successor_priority())
 						continue;
 
 					Time t_high_wos = state_space_data.next_certain_higher_priority_seq_source_job_release(n, j, upbnd_t_wc + 1);
@@ -875,7 +881,12 @@ namespace NP {
 				{
 					const Job<Time>& j = **it;
 					DM(j << " (" << j.get_job_index() << ")" << std::endl);
-					// stop looking once we've left the window of interest
+					// if the job priority is lower than than the minimum priority of the next dispatched job, it will not be dispatched next
+					// (remember that lower number means higher priority)
+					if (j.get_priority() > n.get_min_successor_priority())
+						continue;
+
+					// don't look outside the window of interest
 					if (j.earliest_arrival() > upbnd_t_wc)
 						continue;
 

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -191,7 +191,7 @@ namespace NP {
 				return core_avail[0].min();
 			}
 
-			// return true if the finish time interval the job `j` is known. If so, it writes the finish time interval in `ftimes` 
+			// return true if the finish time interval of the job `j` is known. If so, it writes the finish time interval in `ftimes` 
 			bool get_finish_times(Job_index j, Interval<Time>& ftimes) const
 			{
 				int offset = jft_find(j);
@@ -840,7 +840,7 @@ namespace NP {
 				return num_jobs_scheduled;
 			}
 
-			Priority get_min_successor_priority() const
+			Priority get_next_dispatched_job_min_priority() const
 			{
 				return min_next_prio;
 			}
@@ -1097,28 +1097,29 @@ namespace NP {
 			{
 				jobs_with_pending_succ.reserve(from.jobs_with_pending_succ.size() + 1);
 				bool added_j = successors_of[j].empty(); // we only need to add j if it has successors
-				for (const Job_index& job : from.jobs_with_pending_succ)
+				for (Job_index job : from.jobs_with_pending_succ)
 				{					
 					if (!added_j && job > j)
 					{
-						jobs_with_pending_succ.emplace_back(j);
+						jobs_with_pending_succ.push_back(j);
 						added_j = true;
 					}
 
 					bool successor_pending = false;
 					for (const auto& succ : successors_of[job]) {
 						auto to_job = succ.first->get_job_index();
-						if (!scheduled_jobs.contains(to_job)) {
+						if (!scheduled_jobs.contains(to_job)) 
+						{
 							successor_pending = true;
 							break;
 						}
 					}
 					if (successor_pending)
-						jobs_with_pending_succ.emplace_back(job);
+						jobs_with_pending_succ.push_back(job);
 				}
 
 				if (!added_j)
-					jobs_with_pending_succ.emplace_back(j);
+					jobs_with_pending_succ.push_back(j);
 			}
 
 			// checks that `pred` is the only predecessor of `succ` that is not certainly finished

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -1140,6 +1140,10 @@ namespace NP {
 					Job_index j_idx = p.first->get_job_index();
 					if (j_idx != pred)
 					{
+						// if `p` was not dispatched yet, then `succ` cannot be ready
+						if (!scheduled_jobs.contains(j_idx))
+							return false;
+
 						//  if `p` has a single successor, then we disregard it
 						if (successors_of[j_idx].size() == 1)
 							continue;

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -756,8 +756,9 @@ namespace NP {
 
 			typedef typename Job<Time>::Priority Priority;
 			typedef std::pair<Priority, Job_index> Succ_priority;
+			// for each job `j` in `jobs_with_pending_succ`, `ready_successor_jobs_prio` contains the priority of the smallest priority job that is certainly ready right after `j` completes its execution
 			std::vector<Succ_priority> ready_successor_jobs_prio;
-			Priority min_succ_prio;
+			Priority min_next_prio; // the minimum priority of the first job disptached after the current state
 
 			// no accidental copies
 			Schedule_node(const Schedule_node& origin) = delete;
@@ -792,7 +793,7 @@ namespace NP {
 				, next_certain_successor_jobs_disptach{ Time_model::constants<Time>::infinity() }
 				, next_certain_sequential_source_job_release{ Time_model::constants<Time>::infinity() }
 				, next_certain_gang_source_job_disptach{ Time_model::constants<Time>::infinity() }
-				, min_succ_prio{ Time_model::constants<Time>::infinity() }
+				, min_next_prio{ Time_model::constants<Time>::infinity() }
 			{
 			}
 
@@ -807,7 +808,7 @@ namespace NP {
 				, next_certain_successor_jobs_disptach{ Time_model::constants<Time>::infinity() }
 				, next_certain_sequential_source_job_release{ state_space_data.get_earliest_certain_seq_source_job_release() }
 				, next_certain_gang_source_job_disptach{ Time_model::constants<Time>::infinity() }
-				, min_succ_prio{ Time_model::constants<Time>::infinity() }
+				, min_next_prio{ Time_model::constants<Time>::infinity() }
 			{
 				next_certain_source_job_release = std::min(next_certain_sequential_source_job_release, state_space_data.get_earliest_certain_gang_source_job_release());
 			}
@@ -855,7 +856,7 @@ namespace NP {
 				next_certain_gang_source_job_disptach = Time_model::constants<Time>::infinity();
 				next_certain_source_job_release = std::min(next_certain_sequential_source_job_release, state_space_data.get_earliest_certain_gang_source_job_release());
 				ready_successor_jobs_prio.clear();
-				min_succ_prio = Time_model::constants<Time>::infinity();
+				min_next_prio = Time_model::constants<Time>::infinity();
 			}
 
 			// transition: new node by scheduling a job 'j' in an existing node 'from'
@@ -897,7 +898,7 @@ namespace NP {
 
 			Priority get_min_successor_priority() const
 			{
-				return min_succ_prio;
+				return min_next_prio;
 			}
 
 			Time earliest_job_release() const
@@ -1246,9 +1247,9 @@ namespace NP {
 
 				// calculate the minimum priority of the new job to be dispatched
 				if(ready_successor_jobs_prio.size() < num_cpus)
-					min_succ_prio = Time_model::constants<Time>::infinity();
+					min_next_prio = Time_model::constants<Time>::infinity();
 				else
-					min_succ_prio = ready_successor_jobs_prio[num_cpus - 1].first;
+					min_next_prio = ready_successor_jobs_prio[num_cpus - 1].first;
 
 				assert(ready_successor_jobs_prio.size() <= ready_successor_jobs.size());
 			}

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -1123,8 +1123,8 @@ namespace NP {
 			}
 
 			// checks that `pred` is the only predecessor of `succ` that is not certainly finished
-			// or that `succ` is the only successor of all succ's predecessors except `pred` (i.e., 
-			// the sum of all the successors of all predecessors of `succ` minus the successors of `pred` is equal to 1)
+			// or that `succ` is the only successor of all succ's predecessors (i.e., 
+			// the sum of all the successors of all predecessors of `succ` is equal to 1)
 			bool succ_ready_right_after_pred(const Job_index pred, const Job_index succ, const Successors& successors_of, const Predecessors& predecessors_of)
 			{
 				// if there is only one core then there is at most one job that is not certainly finished
@@ -1138,16 +1138,16 @@ namespace NP {
 				for (const auto& p : predecessors_of[succ]) // check if all other predecessors of `succ` are certainly finished or that they have no other successors than `succ`
 				{
 					Job_index j_idx = p.first->get_job_index();
+					// if `p` was not dispatched yet, then `succ` cannot be ready
+					if (!scheduled_jobs.contains(j_idx))
+						return false;
+
+					//  if `p` has a single successor, then we disregard it
+					if (successors_of[j_idx].size() == 1)
+						continue;
+
 					if (j_idx != pred)
 					{
-						// if `p` was not dispatched yet, then `succ` cannot be ready
-						if (!scheduled_jobs.contains(j_idx))
-							return false;
-
-						//  if `p` has a single successor, then we disregard it
-						if (successors_of[j_idx].size() == 1)
-							continue;
-
 						// If at least one successor of `p` has already been dispatched, then `p` must have finished already.
 						bool is_finished = false;
 						for (const auto& succ_of_pred : successors_of[j_idx])

--- a/include/global/state.hpp
+++ b/include/global/state.hpp
@@ -1137,6 +1137,11 @@ namespace NP {
 
 				for (const auto& p : predecessors_of[succ]) // check if all other predecessors of `succ` are certainly finished or that they have no other successors than `succ`
 				{
+					// if `succ` is not directly ready after `p` completes (i.e., there is a suspension delay between the completion of `p` and start of `succ`), 
+					// then `succ` is not certainly ready when `pred` finishes 
+					if (p.second.max() > 0)
+						return false;
+
 					Job_index j_idx = p.first->get_job_index();
 					// if `p` was not dispatched yet, then `succ` cannot be ready
 					if (!scheduled_jobs.contains(j_idx))

--- a/include/global/state_space_data.hpp
+++ b/include/global/state_space_data.hpp
@@ -274,7 +274,7 @@ namespace NP {
 					}
 
 					Interval<Time> ft{ 0, 0 };
-					s.get_finish_times(pred_idx, ft);					
+					s.get_finish_times(pred_idx, ft);
 					latest_ready_high = std::max(latest_ready_high, ft.max() + high_suspension.max());
 				}
 				return latest_ready_high;

--- a/include/global/state_space_data.hpp
+++ b/include/global/state_space_data.hpp
@@ -274,8 +274,7 @@ namespace NP {
 					}
 
 					Interval<Time> ft{ 0, 0 };
-					s.get_finish_times(pred_idx, ft);
-					
+					s.get_finish_times(pred_idx, ft);					
 					latest_ready_high = std::max(latest_ready_high, ft.max() + high_suspension.max());
 				}
 				return latest_ready_high;


### PR DESCRIPTION
This PR attempts to reduce the pessimism of the DAG analysis on multicore. It implements the following logic to decide if a job `j` with priority `prio(j)` can potentially be the next job dispatched by the scheduler:


Assume `jp` was dispatched to execute on the processor. Assume `jp` has one or more successors. Let `js` be one of the successor jobs of `jp` such that `js` was not dispatched yet and `js` is certainly released before any of its predecessors finishes.

**Lemma 1:**
If `jp` is the only predecessor of `js` or if `jp` is the only predecessor of `js` that may not be finished in the current system state, then `js` is certainly ready when `jp` finishes.
**Proof:**
A job is ready when its is released, all its predecessors are finished. Since by assumption `js` is certainly released before any of its predecessors finishes and `jp` is the last predecessor of `js` to finish, the lemma holds.
**[]**

Let `Sp` be the set of all successors of `jp` that respect the condition defined in Lemma 1 (i.e., `jp` is the only predecessor of `js` or `jp` is the only predecessor of `js` that may not be finished in the current system state). The following Lemma holds.

**Lemma 2:**
When `jp` finishes its execution, the scheduler will dispatch a job `j` on the core used by `jp` such that the priority of `j` is at least the priority of the highest-priority job in `Sp` (i.e., `prio(j) >= max_{js \in Sp}( prio(js) )`). 
**Proof:**
Since all jobs `js` in `Sp` become ready when `jp` finishes, and because the scheduler always dispatch the highest-priority ready job, any job dispatched by the scheduler after `jp` finishes must have a priority at least equal to any jo `js` in `Sp`.
**[]**

Let `P` be the set of jobs such that for every job `jp \in P` the corresponding set `Sp` is not empty, and let `Prio` be a multiset such that for each job `jp \in P`, `Prio` contains an element equal to the priority `max_{js \in Sp}( prio(js) )`.
**Theorem 1:**
If the size of `Prio` is at least `m` (where `m` is the number of cores), then the next job dispatched by the scheduler has a priority that is higher than or equal to the m^th highest element in `Prio`. 

The above theorem can be extended by considering sets of jobs `J` that have a single successor `js`. In that case, the core released by the last job in the set `J` will be assigned to a job with a priority higher than or equal to the priority of `js`.
**Lemma 3:**
Let `J` be the set of all predecessors of `js`. If all jobs in `J` have been dispatched and `js` is the only successor of all jobs in `J`, then `js` is ready as soon as the last job of `J` finishes.

**Lemma 4:**
Let `jl` be the last job in `J` that finishes, then the scheduler will dispatch a job `j` on the core used by `jl` such that the priority of `j` is at least the priority of `js`.

Let `Prio'` be a multiset equal to the union of `Prio` and all jobs `js` that meet the condition set in Lemma 3 (i.e., `js` is the only successor of all its predecessors and all its predecessors have been dispatched already).
**Theorem 1:**
If the size of `Prio'` is at least `m`, then the next job dispatched by the scheduler has a priority that is higher than or equal to the m^th highest element in `Prio'`. 