### PR TITLE
Adding an Action to check code format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: Google
+IndentWidth: 4
+UseTab: ForIndentation
+TabWidth: 4
+ColumnLimit: 100
+DerivePointerAlignment: false
+PointerAlignment: Left
+AllowShortFunctionsOnASingleLine: Empty
+BreakBeforeBraces: Attach
+

--- a/.clang-format
+++ b/.clang-format
@@ -7,4 +7,8 @@ DerivePointerAlignment: false
 PointerAlignment: Left
 AllowShortFunctionsOnASingleLine: Empty
 BreakBeforeBraces: Attach
-
+AllowShortIfStatementsOnASingleLine: Never
+RemoveEmptyLinesInUnwrappedLines: true
+RemoveSemicolon: true
+SeparateDefinitionBlocks: Always
+AllowShortBlocksOnASingleLine: Empty

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,32 @@
+name: Clang Format Check
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Run clang-format
+        run: |
+          FILES=$(find . -regex '.*\.\(cpp\|hpp\|cc\|c\|h\)' -not -path "./build/*")
+          clang-format -i $FILES
+
+      - name: Check for formatting issues
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            echo "❌ Formatting issues found. Please run clang-format locally." >&2
+            git diff
+            exit 1
+          else
+            echo "✅ All files are properly formatted."
+          fi

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,6 +13,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check for non-ASCII characters
+        run: |
+          NON_ASCII=$(grep -P -n "[^\x00-\x7F]" $(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \)) || true)
+          if [[ -n "$NON_ASCII" ]]; then
+            echo "❌ Non-ASCII characters detected in source files:"
+            echo "$NON_ASCII"
+            exit 1
+          else
+            echo "✅ No non-ASCII characters found."
+          fi   
+
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
@@ -29,15 +40,5 @@ jobs:
             exit 1
           else
             echo "✅ All files are properly formatted."
-          fi
-      - name: Check for non-ASCII characters
-        run: |
-          NON_ASCII=$(grep -P -n "[^\x00-\x7F]" $(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \)) || true)
-          if [[ -n "$NON_ASCII" ]]; then
-            echo "❌ Non-ASCII characters detected in source files:"
-            echo "$NON_ASCII"
-            exit 1
-          else
-            echo "✅ No non-ASCII characters found."
-          fi    
+          fi 
       

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,17 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for non-ASCII characters
-        run: |
-          NON_ASCII=$(grep -P -n "[^\x00-\x7F]" $(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \)) || true)
-          if [[ -n "$NON_ASCII" ]]; then
-            echo "❌ Non-ASCII characters detected in source files:"
-            echo "$NON_ASCII"
-            exit 1
-          else
-            echo "✅ No non-ASCII characters found."
-          fi   
-
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run clang-format
         run: |
-          FILES=$(find . -regex '.*\.\(cpp\|hpp\|cc\|c\|h\)' -not -path "./build/*")
+          FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*")
           clang-format -i $FILES
 
       - name: Check for formatting issues

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -30,3 +30,14 @@ jobs:
           else
             echo "✅ All files are properly formatted."
           fi
+      - name: Check for non-ASCII characters
+        run: |
+          NON_ASCII=$(grep -P -n "[^\x00-\x7F]" $(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \)) || true)
+          if [[ -n "$NON_ASCII" ]]; then
+            echo "❌ Non-ASCII characters detected in source files:"
+            echo "$NON_ASCII"
+            exit 1
+          else
+            echo "✅ No non-ASCII characters found."
+          fi    
+      

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run clang-format
         run: |
-          FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*")
+          FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*" -not -path "./build/*")
           clang-format -i $FILES
 
       - name: Check for formatting issues

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -20,13 +20,15 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
+          sudo apt update
+          sudo apt install -y clang-format-21
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-21 100
-          clang-format --version
+          clang-format-21 --version
 
       - name: Run clang-format
         run: |
           FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*" -not -path "./build/*")
-          clang-format -i $FILES
+          clang-format-21 -i $FILES
 
       - name: Check for formatting issues
         run: |

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,8 +13,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format
+      - name: Install clang-format 21
+        run: |
+          sudo apt update
+          sudo apt install -y wget gnupg software-properties-common
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-21 100
+          clang-format --version
 
       - name: Run clang-format
         run: |

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check for formatting issues
         run: |
-          if [[ `git status --porcelain` ]]; then
+          if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
             echo "❌ Formatting issues found. Please run clang-format locally." >&2
             git diff
             exit 1

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-find . -regex '.*\.\(cpp\|hpp\|cc\|c\|h\)' -not -path "./build/*" -exec clang-format -i {} +
+FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*" -not -path "./build/*")
+echo "+ Running clang-format on the following files:"
+echo $FILES
+clang-format -i $FILES

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . -regex '.*\.\(cpp\|hpp\|cc\|c\|h\)' -not -path "./build/*" -exec clang-format -i {} +

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# make sure the script is run from the root of the repository
+if [ ! -d ".git" ]; then
+  echo "This script must be run from the root of the repository."
+  exit 1
+fi
+
 FILES=$(find . -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" \) -not -path "./lib/*" -not -path "./build/*")
 echo "+ Running clang-format on the following files:"
 echo $FILES

--- a/scripts/update-blame.sh
+++ b/scripts/update-blame.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Define the path to the git blame ignore file
+IGNORE_REVS_FILE=".git-blame-ignore-revs"
+
+# make sure the script is run from the root of the repository
+if [ ! -d ".git" ]; then
+  echo "This script must be run from the root of the repository."
+  exit 1
+fi
+
+# Ensure the file exists
+if [ ! -f "$IGNORE_REVS_FILE" ]; then
+  touch "$IGNORE_REVS_FILE"
+  echo "Created .git-blame-ignore-revs file."
+fi
+
+# Add any commit with "chore: auto-format code" in the commit message to .git-blame-ignore-revs
+# We will get the commit hashes of all commits with the message containing "chore: auto-format code"
+COMMIT_HASHES=$(git log --grep="chore: auto-format code" --format="%H")
+
+# If there are any matching commits, append their hashes to .git-blame-ignore-revs
+if [ ! -z "$COMMIT_HASHES" ]; then
+  for commit_hash in $COMMIT_HASHES; do
+    # Check if the commit hash is already in the ignore file
+    if ! grep -q "$commit_hash" "$IGNORE_REVS_FILE"; then
+      echo "$commit_hash" >> "$IGNORE_REVS_FILE"
+      echo "Added commit $commit_hash to $IGNORE_REVS_FILE"
+    else
+      echo "Commit $commit_hash already exists in $IGNORE_REVS_FILE"
+    fi
+  done
+else
+  echo "No 'chore: auto-format code' commits found to add."
+fi
+
+# Set global git config to use the ignore file for blame
+git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+echo "Configured git to ignore reformatting commits for blame."
+
+echo "Formatting and commit update complete."


### PR DESCRIPTION
This PR introduces several important updates to enforce consistent code style and quality in the project:

- **Code Formatting**: Added and enforced the use of `clang-format` with tabs for indentation and braces attached to function definitions, ensuring code consistency across all branches.

#### **Changes Made:**
- Configured `.clang-format` to:
  - Use **tabs** for indentation.
  - Place **braces on the same line** as function declarations.
- Updated **GitHub Actions** workflow to:
  - Automatically check code with `clang-format` on all push and pull request events.
- Added **format.sh** script
  - This script can be run on the root folder with `./script/format.sh` to automatically format all the C++ files according to the `.clang-format` file guideline. 